### PR TITLE
Make location of .xsession-errors configurable

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -981,7 +981,14 @@ session_init (Session *session)
 {
     SessionPrivate *priv = session_get_instance_private (session);
 
-    priv->log_filename = g_strdup (".xsession-errors");
+    if (g_getenv ("XDG_STATE_HOME"))
+        priv->log_filename = g_build_filename (g_getenv ("XDG_STATE_HOME"), ".xsession-errors", NULL);
+    else
+        if (g_getenv ("XDG_CACHE_HOME"))
+            priv->log_filename = g_build_filename (g_getenv ("XDG_STATE_HOME"), ".xsession-errors", NULL);
+        else
+            priv->log_filename = g_build_filename (".cache", ".xsession-errors", NULL);
+
     priv->log_mode = LOG_MODE_BACKUP_AND_TRUNCATE;
     priv->to_child_input = -1;
     priv->from_child_output = -1;


### PR DESCRIPTION
LightDM always uses $HOME/.xsession-errors as the log file because it is harcoded. There are several possible reasons for someone to define another location, for example to write it into the RAM or to just have a tidier $HOME-folder.

This is a long-awaited feature, see: https://github.com/canonical/lightdm/issues/95 and https://bugs.launchpad.net/ubuntu/+source/lightdm/+bug/1001035

Unfortunately, I have no idea how to fix tests to conform this change. Please, feel free to update as needed.