### PR TITLE
x-server: Avoid reusing the local X server if the hostname has changed

### DIFF
--- a/src/seat-local.c
+++ b/src/seat-local.c
@@ -175,9 +175,7 @@ create_x_server (SeatLocal *seat)
     if (command)
         x_server_local_set_command (x_server, command);
 
-    g_autofree gchar *number = g_strdup_printf ("%d", x_server_get_display_number (X_SERVER (x_server)));
-    g_autoptr(XAuthority) cookie = x_authority_new_local_cookie (number);
-    x_server_set_authority (X_SERVER (x_server), cookie);
+    x_server_set_local_authority (X_SERVER (x_server));
 
     const gchar *layout = seat_get_string_property (SEAT (seat), "xserver-layout");
     if (layout)

--- a/src/seat-xvnc.c
+++ b/src/seat-xvnc.c
@@ -57,9 +57,7 @@ seat_xvnc_create_display_server (Seat *seat, Session *session)
 
     g_autoptr(XServerXVNC) x_server = x_server_xvnc_new ();
     priv->x_server = g_object_ref (x_server);
-    g_autofree gchar *number = g_strdup_printf ("%d", x_server_get_display_number (X_SERVER (x_server)));
-    g_autoptr(XAuthority) cookie = x_authority_new_local_cookie (number);
-    x_server_set_authority (X_SERVER (x_server), cookie);
+    x_server_set_local_authority (X_SERVER (x_server));
     x_server_xvnc_set_socket (x_server, g_socket_get_fd (priv->connection));
 
     const gchar *command = config_get_string (config_get_instance (), "VNCServer", "command");

--- a/src/x-authority.c
+++ b/src/x-authority.c
@@ -65,14 +65,6 @@ x_authority_new_cookie (guint16 family, const guint8 *address, gsize address_len
     return x_authority_new (family, address, address_length, number, "MIT-MAGIC-COOKIE-1", cookie, 16);
 }
 
-XAuthority *
-x_authority_new_local_cookie (const gchar *number)
-{
-    gchar hostname[1024];
-    gethostname (hostname, 1024);
-    return x_authority_new_cookie (XAUTH_FAMILY_LOCAL, (guint8 *) hostname, strlen (hostname), number);
-}
-
 void
 x_authority_set_family (XAuthority *auth, guint16 family)
 {

--- a/src/x-authority.h
+++ b/src/x-authority.h
@@ -55,8 +55,6 @@ XAuthority *x_authority_new (guint16 family, const guint8 *address, gsize addres
 
 XAuthority *x_authority_new_cookie (guint16 family, const guint8 *address, gsize address_length, const gchar *number);
 
-XAuthority *x_authority_new_local_cookie (const gchar *number);
-
 void x_authority_set_family (XAuthority *auth, guint16 family);
 
 guint16 x_authority_get_family (XAuthority *auth);

--- a/src/x-server.h
+++ b/src/x-server.h
@@ -55,6 +55,8 @@ gsize x_server_get_authentication_data_length (XServer *server);
 
 void x_server_set_authority (XServer *server, XAuthority *authority);
 
+void x_server_set_local_authority (XServer *server);
+
 XAuthority *x_server_get_authority (XServer *server);
 
 G_END_DECLS


### PR DESCRIPTION
If the hostname has changed while using a local seat, we will fail to connect and return to the greeter. Avoid this behavior by recreating the server.