### PR TITLE
Fix Fedora and Ubuntu GitHub workflow tests, and other test/CI improvements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,23 +10,25 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - ubuntu:rolling
-          - fedora:latest
+          - name: ubuntu
+            tag: rolling
+          - name: fedora
+            tag: latest
 
     runs-on: ubuntu-latest
-    container: ${{ matrix.image }}
+    container: ${{ matrix.image.name }}:${{ matrix.image.tag }}
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Install dependencies (Ubuntu)
-        if: startsWith(matrix.image, 'ubuntu:')
+        if: matrix.image.name == 'ubuntu'
         run: |
           apt-get update
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends dbus gtk-doc-tools intltool libaudit-dev libgcrypt20-dev libgirepository1.0-dev libglib2.0-dev libpam0g-dev libtool libxcb1-dev libxdmcp-dev libxklavier-dev python3 python3-gi python-is-python3 qtbase5-dev valac yelp-tools
 
       - name: Install dependencies (Fedora)
-        if: startsWith(matrix.image, 'fedora:')
+        if: matrix.image.name == 'fedora'
         run: |
           dnf install -y audit-libs-devel dbus-daemon gcc gcc-c++ gobject-introspection-devel glib2-devel gtk-doc intltool libgcrypt-devel libtool libxcb-devel libxklavier-devel libXdmcp-devel make pam-devel python3-gobject qt5-qtbase-devel redhat-rpm-config vala yelp-tools
 
@@ -40,5 +42,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: Test Log
+          name: Test Log ${{ matrix.image.name }} ${{ matrix.image.tag }}
           path: tests/test-suite.log

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           ./autogen.sh --disable-silent-rules --enable-gtk-doc
           make
-          make check
+          make check DEBUG=true
 
       - name: Upload Test Log
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     container: ${{ matrix.image }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install dependencies (Ubuntu)
         if: startsWith(matrix.image, 'ubuntu:')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - ubuntu:rolling
           - fedora:latest
 
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload Test Log
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Test Log
           path: tests/test-suite.log

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           ./autogen.sh --disable-silent-rules --enable-gtk-doc
           make
-          make check DEBUG=true
+          make check DEBUG=true || { cat tests/test-suite.log >&2; exit 1; }
 
       - name: Upload Test Log
         if: failure()

--- a/tests/data/session.conf
+++ b/tests/data/session.conf
@@ -1,6 +1,6 @@
 <busconfig>
   <type>session</type>
-  <listen>unix:tmpdir=/tmp</listen>
+  <listen>unix:dir=/tmp</listen>
   <policy context="default">
     <allow send_destination="*" eavesdrop="true"/>
     <allow eavesdrop="true"/>

--- a/tests/data/system.conf
+++ b/tests/data/system.conf
@@ -1,6 +1,6 @@
 <busconfig>
   <type>system</type>
-  <listen>unix:tmpdir=/tmp</listen>
+  <listen>unix:dir=/tmp</listen>
   <policy context="default">
     <allow send_destination="*" eavesdrop="true"/>
     <allow eavesdrop="true"/>

--- a/tests/src/libsystem.c
+++ b/tests/src/libsystem.c
@@ -210,17 +210,20 @@ redirect_path (const gchar *path)
     /*
      * Don't redirect /tmp/dbus-* so that the test runner and its invoked
      * LightDM can interact with the D-Bus daemon launched by dbus-env.c.  The
-     * D-Bus config has <listen>unix:tmpdir=/tmp</listen>, and with that config
-     * the D-Bus specification [1] says that the daemon will create a socket
+     * D-Bus config has <listen>unix:dir=/tmp</listen>, and with that config the
+     * D-Bus specification [1] says that the daemon will create a socket file
      * whose name matches /tmp/dbus-*.
      *
-     * (With unix:tmpdir, dbus-daemon is allowed, but not required, to create
-     * abstract sockets instead of file-based sockets.  Abstract sockets are
-     * unaffected by the redirection of /tmp to $LIGHTDM_TEST_ROOT because they
-     * don't actually exist in the filesystem.  An exception is required here
-     * anyway because not all systems support abstract sockets, and starting
-     * with v1.15.2 dbus-daemon doesn't use abstract sockets even on systems
-     * that support them [2].)
+     * (If the configs had unix:tmpdir instead of unix:dir, dbus-daemon would be
+     * allowed, but not required, to create abstract sockets instead of
+     * file-based sockets.  Abstract sockets are unaffected by the redirection
+     * of /tmp to $LIGHTDM_TEST_ROOT because they don't actually exist in the
+     * filesystem.  That seems like a good feature in this case, but not all
+     * systems support abstract sockets, and starting with v1.15.2 dbus-daemon
+     * doesn't use abstract sockets even on systems that support them [2].
+     * Thus, an exception for /tmp/dbus-* is required here regardless.  To avoid
+     * platform-specific cold code paths, unix:dir is used to force the use of
+     * normal socket files.)
      *
      * [1] https://dbus.freedesktop.org/doc/dbus-specification.html#transports-unix-domain-sockets-addresses
      * [2] https://gitlab.freedesktop.org/dbus/dbus/-/blob/35ade3c8f7aca16d1c6289828a2597859d1c503b/NEWS#L129-L147

--- a/tests/src/test-runner.c
+++ b/tests/src/test-runner.c
@@ -990,6 +990,9 @@ run_commands (void)
         statuses = g_list_append (statuses, g_strdup (line->text));
         line->done = TRUE;
 
+        if (getenv ("DEBUG"))
+            g_print ("%s\n", line->text);
+
         handle_command (line->text + 1);
     }
 }

--- a/tests/src/test-runner.c
+++ b/tests/src/test-runner.c
@@ -2770,7 +2770,9 @@ main (int argc, char **argv)
     if (g_key_file_has_key (config, "test-runner-config", "timeout", NULL))
         status_timeout_ms = g_key_file_get_integer (config, "test-runner-config", "timeout", NULL) * 1000;
 
-    dbus_conn = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, NULL);
+    dbus_conn = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &error);
+    if (!dbus_conn)
+        g_error("Failed to connect to system D-Bus: %s", error->message);
 
     /* Start D-Bus services */
     if (!g_key_file_get_boolean (config, "test-runner-config", "disable-upower", NULL))

--- a/tests/src/test-runner.c
+++ b/tests/src/test-runner.c
@@ -1209,8 +1209,8 @@ start_upower_daemon (void)
     g_bus_own_name (G_BUS_TYPE_SYSTEM,
                     "org.freedesktop.UPower",
                     G_BUS_NAME_OWNER_FLAGS_NONE,
-                    upower_name_acquired_cb,
                     NULL,
+                    upower_name_acquired_cb,
                     NULL,
                     NULL,
                     NULL);
@@ -2359,8 +2359,8 @@ start_accounts_service_daemon (void)
     g_bus_own_name (G_BUS_TYPE_SYSTEM,
                     "org.freedesktop.Accounts",
                     G_BUS_NAME_OWNER_FLAGS_NONE,
-                    accounts_name_acquired_cb,
                     NULL,
+                    accounts_name_acquired_cb,
                     NULL,
                     NULL,
                     NULL);

--- a/tests/src/test-runner.c
+++ b/tests/src/test-runner.c
@@ -921,23 +921,24 @@ handle_command (const gchar *command)
 static void
 run_commands (void)
 {
-    /* Stop daemon if requested */
     while (TRUE)
     {
-        /* Commands start with an asterisk */
         ScriptLine *line = get_script_line (NULL);
-        if (!line || line->text[0] != '*')
-            break;
+        if (!line)
+        {
+            quit (EXIT_SUCCESS);
+            return;
+        }
+
+        /* Commands start with an asterisk */
+        if (line->text[0] != '*')
+            return;
 
         statuses = g_list_append (statuses, g_strdup (line->text));
         line->done = TRUE;
 
         handle_command (line->text + 1);
     }
-
-    /* Stop at the end of the script */
-    if (get_script_line (NULL) == NULL)
-        quit (EXIT_SUCCESS);
 }
 
 static gboolean

--- a/tests/src/test-runner.c
+++ b/tests/src/test-runner.c
@@ -467,8 +467,8 @@ handle_command (const gchar *command)
             g_string_append (command_line, " --debug");
         g_string_append_printf (command_line, " --cache-dir %s/cache", temp_dir);
 
-        test_runner_command = g_strdup_printf ("PATH=%s LD_PRELOAD=%s LD_LIBRARY_PATH=%s LIGHTDM_TEST_ROOT=%s DBUS_SESSION_BUS_ADDRESS=%s %s\n",
-                                               g_getenv ("PATH"), g_getenv ("LD_PRELOAD"), g_getenv ("LD_LIBRARY_PATH"), g_getenv ("LIGHTDM_TEST_ROOT"), g_getenv ("DBUS_SESSION_BUS_ADDRESS"),
+        test_runner_command = g_strdup_printf ("PATH=%s LD_PRELOAD=%s LD_LIBRARY_PATH=%s LIGHTDM_TEST_ROOT=%s DBUS_SESSION_BUS_ADDRESS=%s DBUS_SYSTEM_BUS_ADDRESS=%s %s\n",
+                                               g_getenv ("PATH"), g_getenv ("LD_PRELOAD"), g_getenv ("LD_LIBRARY_PATH"), g_getenv ("LIGHTDM_TEST_ROOT"), g_getenv ("DBUS_SESSION_BUS_ADDRESS"), g_getenv ("DBUS_SYSTEM_BUS_ADDRESS"),
                                                command_line->str);
 
         gchar **lightdm_argv;

--- a/tests/src/test-runner.c
+++ b/tests/src/test-runner.c
@@ -470,6 +470,8 @@ handle_command (const gchar *command)
         test_runner_command = g_strdup_printf ("PATH=%s LD_PRELOAD=%s LD_LIBRARY_PATH=%s LIGHTDM_TEST_ROOT=%s DBUS_SESSION_BUS_ADDRESS=%s DBUS_SYSTEM_BUS_ADDRESS=%s %s\n",
                                                g_getenv ("PATH"), g_getenv ("LD_PRELOAD"), g_getenv ("LD_LIBRARY_PATH"), g_getenv ("LIGHTDM_TEST_ROOT"), g_getenv ("DBUS_SESSION_BUS_ADDRESS"), g_getenv ("DBUS_SYSTEM_BUS_ADDRESS"),
                                                command_line->str);
+        if (getenv ("DEBUG"))
+            g_print ("Command line: %s\n", test_runner_command);
 
         gchar **lightdm_argv;
         g_autoptr(GError) error = NULL;


### PR DESCRIPTION
The most important commits are:

  * tests: Don't redirect `/tmp/dbus-*` to `$LIGHTDM_TEST_ROOT/tmp/dbus-*`
  * ci: Re-enable Ubuntu tests

The first of those two commits fixes the `test.yaml` GitHub workflow for both Fedora and Ubuntu.  I don't know why `dbus-daemon` is creating a Unix domain socket in the filesystem instead of creating an abstract socket.  Maybe some security policy is preventing abstract sockets from working in Docker on the runner?

The remaining commits are test/CI tweaks I made while troubleshooting that I thought were worth including.

Please do not squash this when merging—the commits are intended to be separate.  I will rebase these as needed to incorporate feedback or update to the latest `main`.