### PR TITLE
Allow Wayland sessions to start on seat0 on kernels with no VTs

### DIFF
--- a/src/lightdm.c
+++ b/src/lightdm.c
@@ -424,9 +424,11 @@ add_login1_seat (Login1Seat *login1_seat)
         set_seat_properties (seat, seat_name);
 
         gboolean can_multi_session = login1_seat_get_can_multi_session (login1_seat);
+        gboolean can_tty = login1_seat_get_can_tty (login1_seat);
         if (!can_multi_session)
             g_debug ("Seat %s has property CanMultiSession=no", seat_name);
         seat_set_supports_multi_session (seat, can_multi_session);
+        seat_set_can_tty (seat, can_tty);
 
         if (is_seat0)
             seat_set_property (seat, "exit-on-failure", "true");

--- a/src/login1.c
+++ b/src/login1.c
@@ -67,6 +67,9 @@ typedef struct
 
     /* TRUE if can do session switching */
     gboolean can_multi_session;
+
+    /* TRUE if seat has TTYs */
+    gboolean can_tty;
 } Login1SeatPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (Login1Service, login1_service, G_TYPE_OBJECT)
@@ -199,6 +202,8 @@ add_seat (Login1Service *service, const gchar *id, const gchar *path)
                 s_priv->can_graphical = g_variant_get_boolean (value);
             else if (strcmp (name, "CanMultiSession") == 0 && g_variant_is_of_type (value, G_VARIANT_TYPE_BOOLEAN))
                 s_priv->can_multi_session = g_variant_get_boolean (value);
+            else if (strcmp (name, "CanTTY") == 0 && g_variant_is_of_type (value, G_VARIANT_TYPE_BOOLEAN))
+                s_priv->can_tty = g_variant_get_boolean (value);
         }
     }
 
@@ -517,6 +522,14 @@ login1_seat_get_can_multi_session (Login1Seat *seat)
     Login1SeatPrivate *priv = login1_seat_get_instance_private (seat);
     g_return_val_if_fail (seat != NULL, FALSE);
     return priv->can_multi_session;
+}
+
+gboolean
+login1_seat_get_can_tty (Login1Seat *seat)
+{
+    Login1SeatPrivate *priv = login1_seat_get_instance_private (seat);
+    g_return_val_if_fail (seat != NULL, FALSE);
+    return priv->can_tty;
 }
 
 static void

--- a/src/login1.h
+++ b/src/login1.h
@@ -80,6 +80,8 @@ gboolean login1_seat_get_can_graphical (Login1Seat *seat);
 
 gboolean login1_seat_get_can_multi_session (Login1Seat *seat);
 
+gboolean login1_seat_get_can_tty (Login1Seat *seat);
+
 G_END_DECLS
 
 #endif /* _LOGIN1_H_ */

--- a/src/seat-local.c
+++ b/src/seat-local.c
@@ -120,7 +120,7 @@ display_server_transition_plymouth_cb (DisplayServer *display_server, Seat *seat
 static gint
 get_vt (SeatLocal *seat, DisplayServer *display_server)
 {
-    if (strcmp (seat_get_name (SEAT (seat)), "seat0") != 0)
+    if (strcmp (seat_get_name (SEAT (seat)), "seat0") != 0 || !seat_get_can_tty ( SEAT (seat)))
         return -1;
 
     /* If Plymouth is running, stop it */
@@ -270,7 +270,7 @@ seat_local_get_active_session (Seat *seat)
      * FIXME: Use seat_get_expected_active_session even for seat0, falling back
      * to VT probing if the systemd-logind service is unavailable.
      */
-    if (strcmp (seat_get_name (seat), "seat0") != 0)
+    if (strcmp (seat_get_name (seat), "seat0") != 0 || !seat_get_can_tty (seat))
         return seat_get_expected_active_session (seat);
 
     gint vt = vt_get_active ();

--- a/src/seat.c
+++ b/src/seat.c
@@ -39,6 +39,9 @@ typedef struct
     /* TRUE if this seat can run multiple sessions at once */
     gboolean supports_multi_session;
 
+    /* TRUE if this seat has TTYs */
+    gboolean can_tty;
+
     /* TRUE if display server can be shared for sessions */
     gboolean share_display_server;
 
@@ -207,6 +210,14 @@ seat_set_share_display_server (Seat *seat, gboolean share_display_server)
     priv->share_display_server = share_display_server;
 }
 
+void
+seat_set_can_tty (Seat *seat, gboolean can_tty)
+{
+    SeatPrivate *priv = seat_get_instance_private (seat);
+    g_return_if_fail (seat != NULL);
+    priv->can_tty = can_tty;
+}
+
 gboolean
 seat_start (Seat *seat)
 {
@@ -355,6 +366,14 @@ seat_get_can_switch (Seat *seat)
     SeatPrivate *priv = seat_get_instance_private (seat);
     g_return_val_if_fail (seat != NULL, FALSE);
     return seat_get_boolean_property (seat, "allow-user-switching") && priv->supports_multi_session;
+}
+
+gboolean
+seat_get_can_tty (Seat *seat)
+{
+    SeatPrivate *priv = seat_get_instance_private (seat);
+    g_return_val_if_fail (seat != NULL, FALSE);
+    return priv->can_tty;
 }
 
 gboolean

--- a/src/seat.h
+++ b/src/seat.h
@@ -83,6 +83,8 @@ void seat_set_supports_multi_session (Seat *seat, gboolean supports_multi_sessio
 
 void seat_set_share_display_server (Seat *seat, gboolean share_display_server);
 
+void seat_set_can_tty (Seat *seat, gboolean can_tty);
+
 gboolean seat_start (Seat *seat);
 
 GList *seat_get_sessions (Seat *seat);
@@ -100,6 +102,8 @@ Session *seat_get_expected_active_session (Seat *seat);
 Session *seat_find_session_by_login1_id (Seat *seat, const gchar *login1_session_id);
 
 gboolean seat_get_can_switch (Seat *seat);
+
+gboolean seat_get_can_tty (Seat *seat);
 
 gboolean seat_get_allow_guest (Seat *seat);
 


### PR DESCRIPTION
This is an attempt to fix #314 