### PR TITLE
Add support for changing the home directory in PAM modules

### DIFF
--- a/src/session-child.c
+++ b/src/session-child.c
@@ -543,6 +543,8 @@ session_child_run (int argc, char **argv)
     if (!home_directory) {
         home_directory = user_get_home_directory (user);
     }
+    if (version >= 4)
+        write_string (home_directory);
 
     /* Open a connection to the system bus for ConsoleKit - we must keep it open or CK will close the session */
     g_autoptr(GError) error = NULL;

--- a/src/session.c
+++ b/src/session.c
@@ -812,7 +812,7 @@ session_real_run (Session *session)
         x_authority_filename = g_build_filename (dir, "xauthority", NULL);
     }
     else
-        x_authority_filename = g_build_filename (user_get_home_directory (session_get_user (session)), ".Xauthority", NULL);
+        x_authority_filename = g_strdup (".Xauthority");
 
     /* Make sure shared user directory for this user exists */
     if (!priv->remote_host_name)

--- a/src/session.h
+++ b/src/session.h
@@ -118,6 +118,8 @@ gboolean session_get_is_started (Session *session);
 
 const gchar *session_get_username (Session *session);
 
+const gchar *session_get_home_directory (Session *session);
+
 const gchar *session_get_login1_session_id (Session *session);
 
 const gchar *session_get_console_kit_cookie (Session *session);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -256,7 +256,8 @@ TESTS = \
 	test-wayland-greeter \
 	test-wayland-session \
 	test-invalid-seat \
-	test-seatdefaults-still-supported
+	test-seatdefaults-still-supported \
+	test-change-home-dir-on-session
 
 #	test-switch-to-greeter-return-session-repeat
 #	test-session-exit-error
@@ -389,6 +390,7 @@ EXTRA_DIST = \
 	scripts/autologin-timeout-logout.conf \
 	scripts/autologin-xserver-crash.conf \
 	scripts/change-authentication.conf \
+	scripts/change-home-dir-on-session.conf \
 	scripts/cancel-authentication.conf \
 	scripts/console-kit.conf \
 	scripts/console-kit-no-xdg-runtime.conf \

--- a/tests/scripts/change-home-dir-on-session.conf
+++ b/tests/scripts/change-home-dir-on-session.conf
@@ -1,0 +1,34 @@
+#
+# Check home directory is set correctly in session after having been changed by PAM
+#
+
+[Seat:*]
+autologin-user=change-home-dir
+user-session=default
+
+#?*START-DAEMON
+#?RUNNER DAEMON-START
+
+# X server starts
+#?XSERVER-0 START VT=7 SEAT=seat0
+
+# Daemon connects when X server is ready
+#?*XSERVER-0 INDICATE-READY
+#?XSERVER-0 INDICATE-READY
+#?XSERVER-0 ACCEPT-CONNECT
+
+# Session starts
+#?SESSION-X-0 START XDG_SEAT=seat0 XDG_VTNR=7 XDG_GREETER_DATA_DIR=.*/change-home-dir XDG_SESSION_TYPE=x11 XDG_SESSION_DESKTOP=default USER=change-home-dir
+#?LOGIN1 ACTIVATE-SESSION SESSION=c0
+#?XSERVER-0 ACCEPT-CONNECT
+#?SESSION-X-0 CONNECT-XSERVER
+
+# Check environment variables
+#?*SESSION-X-0 READ-ENV NAME=HOME
+#?SESSION-X-0 READ-ENV NAME=HOME VALUE=.*/users/change-home-dir
+
+# Cleanup
+#?*STOP-DAEMON
+#?SESSION-X-0 TERMINATE SIGNAL=15
+#?XSERVER-0 TERMINATE SIGNAL=15
+#?RUNNER DAEMON-EXIT STATUS=0

--- a/tests/src/test-runner.c
+++ b/tests/src/test-runner.c
@@ -2772,13 +2772,15 @@ main (int argc, char **argv)
         {"corrupt-xauth",    "password",  "Corrupt Xauthority", 1032},
         /* User to test properties */
         {"prop-user",        "",          "TEST",               1033},
+        /* This account has the home directory changed by PAM during authentication */
+        {"change-home-dir",    "",       "Change Home Dir User", 1034},
         {NULL,               NULL,        NULL,                    0}
     };
     g_autoptr(GString) passwd_data = g_string_new ("");
     g_autoptr(GString) group_data = g_string_new ("");
     for (int i = 0; users[i].user_name; i++)
     {
-        if (strcmp (users[i].user_name, "mount-home-dir") != 0 && strcmp (users[i].user_name, "make-home-dir") != 0)
+        if (strcmp (users[i].user_name, "mount-home-dir") != 0 && strcmp (users[i].user_name, "make-home-dir") != 0 && strcmp (users[i].user_name, "change-home-dir") != 0)
         {
             g_autofree gchar *path = g_build_filename (home_dir, users[i].user_name, NULL);
             g_mkdir_with_parents (path, 0755);

--- a/tests/test-change-home-dir-on-session
+++ b/tests/test-change-home-dir-on-session
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner change-home-dir-on-session test-gobject-greeter


### PR DESCRIPTION
PAM modules such as pam_mklocaluser may change or even create the home directory. Currently, LightDM assumes that the home directory will not change when opening the PAM session, the user's home directory is obtained via getpwent() after authentication but before opening the session.  Fix this by trying to update the user's home directory from the HOME environment variable from PAM after opening the session.
Furthermore, if the Xauthority file is not stored in a system directory, the daemon hardcodes its path to the user's home directory and passes it as an absolute path to the session child.  Fix this by passing it as a relative path so that the actual path can be constructed after the PAM session has been opened and the home directory has potentially been updated.

This fixes #322.