### PR TITLE
Use setusercontext(3) where available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AC_CHECK_HEADERS(security/pam_appl.h, [], AC_MSG_ERROR(PAM not found))
 
 AC_CHECK_HEADERS(gcrypt.h, [], AC_MSG_ERROR(libgcrypt not found))
 
-AC_CHECK_FUNCS(setresgid setresuid clearenv __getgroups_chk)
+AC_CHECK_FUNCS(setresgid setresuid setusercontext clearenv __getgroups_chk)
 
 PKG_CHECK_MODULES(LIGHTDM, [
     glib-2.0 >= 2.44


### PR DESCRIPTION
Hi,

I recreated the patch suggested by @DanielO in issue #269 as a pull request.

This patch adds checks in configure for setusercontext(3) and then uses it, if available, to switch user after forking int he session.

Using this method leverages existing FreeBSD code to se the user session that takes into account the login.conf values and also allows automated substitution of ~ (tilde) and $ (dollar) characters with their values.

This solves issues on FreeBSD and the patch is being discussed for inclusion in the FreeBSD port here: https://bugs.freebsd.org/266532

Manual page for setusercontext: [setusercontext(3)](https://man.freebsd.org/cgi/man.cgi?query=setusercontext&apropos=0&sektion=0&manpath=FreeBSD+14.0-RELEASE+and+Ports&arch=default&format=html)