### PR TITLE
LightDM failsafe handler and restart directives

### DIFF
--- a/debian/lightdm-failure-handler.service
+++ b/debian/lightdm-failure-handler.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Handle LightDM failure
+
+[Service]
+Type=oneshot
+ExecStart=/bin/mv /etc/issue /etc/issue.restore; /bin/sh -c 'echo -e "LightDM has failed to start. You are now in a TTY for troubleshooting...\nYou can log in and check for details in logs." > /etc/issue; /usr/bin/chvt 4'
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/lightdm-success-handler.service
+++ b/debian/lightdm-success-handler.service
@@ -5,7 +5,7 @@ After=lightdm.service
 
 [Service]
 Type=oneshot
-ExecStart=/bin/mv /etc/issue.restore /etc/issue
+ExecStart=/bin/sh -c 'test -f /etc/issue.restore && mv /etc/issue.restore /etc/issue || echo -e "Linux \\\\r (\\\\l)\n\n" > /etc/issue'
 
 [Install]
 WantedBy=graphical.target

--- a/debian/lightdm-success-handler.service
+++ b/debian/lightdm-success-handler.service
@@ -5,7 +5,7 @@ After=lightdm.service
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'test -f /etc/issue.restore && mv /etc/issue.restore /etc/issue || echo -e "Linux \\\\r (\\\\l)\n\n" > /etc/issue'
+ExecStart=/bin/sh -c 'test -f /etc/issue.restore && mv /etc/issue.restore /etc/issue || echo "File /etc/issue.restore not found. No restore action needed."'
 
 [Install]
 WantedBy=graphical.target

--- a/debian/lightdm-success-handler.service
+++ b/debian/lightdm-success-handler.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Reset /etc/issue after LightDM starts successfully
+Requires=lightdm.service
+After=lightdm.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/mv /etc/issue.restore /etc/issue
+
+[Install]
+WantedBy=graphical.target

--- a/debian/lightdm.service
+++ b/debian/lightdm.service
@@ -3,7 +3,7 @@ Description=Light Display Manager
 Documentation=man:lightdm(1)
 Conflicts=getty@tty7.service plymouth-quit.service
 After=systemd-user-sessions.service getty@tty7.service plymouth-quit.service systemd-hostnamed.service
-StartLimitInterval=60s
+StartLimitIntervalSec=60s
 StartLimitBurst=5
 OnFailure=lightdm-failure-handler.service
 

--- a/debian/lightdm.service
+++ b/debian/lightdm.service
@@ -3,6 +3,9 @@ Description=Light Display Manager
 Documentation=man:lightdm(1)
 Conflicts=getty@tty7.service plymouth-quit.service
 After=systemd-user-sessions.service getty@tty7.service plymouth-quit.service systemd-hostnamed.service
+StartLimitInterval=60s
+StartLimitBurst=5
+OnFailure=lightdm-failure-handler.service
 
 [Service]
 # temporary safety check until all DMs are converted to correct
@@ -10,4 +13,5 @@ After=systemd-user-sessions.service getty@tty7.service plymouth-quit.service sys
 ExecStartPre=/bin/sh -c '[ "$(basename $(cat /etc/X11/default-display-manager 2>/dev/null))" = "lightdm" ]'
 ExecStart=/usr/sbin/lightdm
 Restart=always
+RestartSec=15s
 BusName=org.freedesktop.DisplayManager

--- a/debian/lightdm.service
+++ b/debian/lightdm.service
@@ -13,5 +13,5 @@ OnFailure=lightdm-failure-handler.service
 ExecStartPre=/bin/sh -c '[ "$(basename $(cat /etc/X11/default-display-manager 2>/dev/null))" = "lightdm" ]'
 ExecStart=/usr/sbin/lightdm
 Restart=always
-RestartSec=15s
+RestartSec=5s
 BusName=org.freedesktop.DisplayManager


### PR DESCRIPTION
This PR is in reference to https://github.com/canonical/lightdm/issues/337

In a few different scenarios, I've experienced situations where a child process spawned by LightDM (such as x11) fails to start. As per the instructions in [lightdm.service](https://github.com/canonical/lightdm/blob/main/debian/lightdm.service#L12), upon failure, LightDM will `Restart=always`.
The problem that can arise from this is when one of those services is failing for a very specific reason that requires the user to make changes. In a scenario where such a service will fail 100% of the time, this will cause LightDM to `Restart=always` 100% of the time, which will eventually trigger systemd's rate-limiting mechanism, resulting in logs that appear like this:
```
systemd[1]: lightdm.service: Service hold-off time over, scheduling restart.
systemd[1]: Stopped LightDM.                        
systemd[1]: lightdm.service: Start request repeated too quickly.
systemd[1]: Failed to start LightDM.                
systemd[1]: lightdm.service: Unit entered failed state.       
systemd[1]: lightdm.service: Failed with result 'exit-code'. 
```

The problem is that, depending on the failure, the user might only see a black screen, with no indication that anything is wrong other than the screen being black and nothing loading. The user would only be able to discover the details in the aforementioned logs if they switched to a different TTY, logged in, and checked the logs. From there, they would be able to discover why the failure happened and fix the issue.

The changes that I am proposing are essentially a shortcut to what I just described.

The `lightdm.service` file now includes StartLimit IntervalSec and Burst values, a RestartSec rate, and an OnFailure action. The values I've proposed I _think_ make sense:
The service has a restart delay of 5 seconds in between resets, and if the service restarts more than 5 times within a 60s period, then the service will be in a failed state. In the event of it being in a failed state, it triggers the OnFailure action:[debian/lightdm-failure-handler.service](https://github.com/wallentx/lightdm/blob/801d1f0a45fdf141a6c92ea9316b5e2d5ea08bd7/debian/lightdm-failure-handler.service)

This service makes a copy of `/etc/issue` (the MOTD-like message you see above a TTY login) to `/etc/issue.restore`, and writes in a new message "hint" to `/etc/issue` that lets the user know what to do. It then changes the user to `TTY4` (I only chose 4 because I've noticed others to be reserved for other things, or unavailable.. someone should check my reasoning here though) so that they can see that message, and log in to troubleshoot.

Upon [successful login](https://github.com/wallentx/lightdm/blob/wallentx/lightdm-failsafe-handler/debian/lightdm-success-handler.service) of LightDM, if an `/etc/issue.restore` file exists, it will replace `/etc/issue` (which presumably has the "hint" we wrote earlier). If no .restore file is found, no action is taken.


I couldn't find anything else in the repo specifically that referenced the packaging or manifest of the .service files, but maybe that is handled elsewhere.