### PR TITLE
Switch back to the greeter when logind emits SecureAttentionKey 

### DIFF
--- a/src/lightdm.c
+++ b/src/lightdm.c
@@ -551,6 +551,13 @@ login1_service_seat_removed_cb (Login1Service *service, Login1Seat *login1_seat)
     remove_login1_seat (login1_seat);
 }
 
+static void
+login1_service_seat_attention_key_cb (Login1Service *service, Login1Seat *login1_seat)
+{
+   Seat *seat = display_manager_get_seat (display_manager, login1_seat_get_id (login1_seat));
+   seat_switch_to_greeter (seat);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -891,6 +898,7 @@ main (int argc, char **argv)
         {
             g_signal_connect (login1_service_get_instance (), LOGIN1_SERVICE_SIGNAL_SEAT_ADDED, G_CALLBACK (login1_service_seat_added_cb), NULL);
             g_signal_connect (login1_service_get_instance (), LOGIN1_SERVICE_SIGNAL_SEAT_REMOVED, G_CALLBACK (login1_service_seat_removed_cb), NULL);
+            g_signal_connect (login1_service_get_instance (), LOGIN1_SERVICE_SIGNAL_SEAT_ATTENTION_KEY, G_CALLBACK (login1_service_seat_attention_key_cb), NULL);
 
             for (GList *link = login1_service_get_seats (login1_service_get_instance ()); link; link = link->next)
             {

--- a/src/login1.h
+++ b/src/login1.h
@@ -24,6 +24,7 @@ G_BEGIN_DECLS
 
 #define LOGIN1_SERVICE_SIGNAL_SEAT_ADDED   "seat-added"
 #define LOGIN1_SERVICE_SIGNAL_SEAT_REMOVED "seat-removed"
+#define LOGIN1_SERVICE_SIGNAL_SEAT_ATTENTION_KEY "seat-attention-key"
 
 #define LOGIN1_SEAT_SIGNAL_CAN_GRAPHICAL_CHANGED "can-graphical-changed"
 #define LOGIN1_SIGNAL_ACTIVE_SESION_CHANGED "active-session-changed"
@@ -50,6 +51,7 @@ typedef struct
     GObjectClass parent_class;
     void (*seat_added)(Login1Service *service, Login1Seat *seat);
     void (*seat_removed)(Login1Service *service, Login1Seat *seat);
+    void (*seat_attention_key)(Login1Service *service, Login1Seat *seat);
 } Login1ServiceClass;
 
 GType login1_service_get_type (void);


### PR DESCRIPTION
This depends on https://github.com/systemd/systemd/pull/29542 which is going to be included in the upcoming systemd v257 release as it was merged