### PR TITLE
Add client library version for Qt6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,12 +25,12 @@ jobs:
         if: matrix.image.name == 'ubuntu'
         run: |
           apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends dbus gtk-doc-tools intltool libaudit-dev libgcrypt20-dev libgirepository1.0-dev libglib2.0-dev libpam0g-dev libtool libxcb1-dev libxdmcp-dev libxklavier-dev python3 python3-gi python-is-python3 qtbase5-dev valac yelp-tools
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends dbus gtk-doc-tools intltool libaudit-dev libgcrypt20-dev libgirepository1.0-dev libglib2.0-dev libpam0g-dev libtool libxcb1-dev libxdmcp-dev libxklavier-dev python3 python3-gi python-is-python3 qtbase5-dev qt6-base-dev valac yelp-tools
 
       - name: Install dependencies (Fedora)
         if: matrix.image.name == 'fedora'
         run: |
-          dnf install -y audit-libs-devel dbus-daemon gcc gcc-c++ gobject-introspection-devel glib2-devel gtk-doc intltool libgcrypt-devel libtool libxcb-devel libxklavier-devel libXdmcp-devel make pam-devel python3-gobject qt5-qtbase-devel redhat-rpm-config vala yelp-tools
+          dnf install -y audit-libs-devel dbus-daemon gcc gcc-c++ gobject-introspection-devel glib2-devel gtk-doc intltool libgcrypt-devel libtool libxcb-devel libxklavier-devel libXdmcp-devel make pam-devel python3-gobject qt5-qtbase-devel qt6-qtbase-devel redhat-rpm-config vala yelp-tools
 
       - name: Build and test
         run: |

--- a/configure.ac
+++ b/configure.ac
@@ -105,7 +105,7 @@ if test x"$enable_liblightdm_qt5" != "xno"; then
       fi
     ])
 
-    AC_CHECK_TOOLS(MOC5, [moc-qt5 moc])
+    QT5_VALIDATE_MOC(MOC5)
     if test x$MOC5 = x; then
         compile_liblightdm_qt5=no
         if test "x$enable_liblightdm_qt5" != xauto; then
@@ -120,6 +120,35 @@ if test x"$enable_liblightdm_qt5" != "xno"; then
     fi
 fi
 AM_CONDITIONAL(COMPILE_LIBLIGHTDM_QT5, test x"$compile_liblightdm_qt5" != "xno")
+
+AC_ARG_ENABLE(liblightdm-qt6,
+	AS_HELP_STRING([--enable-liblightdm-qt6],[Enable LightDM client Qt6 libraries [[default=auto]]]),
+	[enable_liblightdm_qt6=$enableval],
+	[enable_liblightdm_qt6="auto"])
+compile_liblightdm_qt6=no
+if test x"$enable_liblightdm_qt6" != "xno"; then
+    PKG_CHECK_MODULES(LIBLIGHTDM_QT6, [
+        Qt6Core
+        Qt6DBus
+        Qt6Gui
+    ],
+    [compile_liblightdm_qt6=yes],
+    [if test "x$enable_liblightdm_qt6" != xauto; then
+        AC_MSG_FAILURE(
+          [--enable-liblightdm-qt6 was given, but test for Qt6 failed])
+      fi
+    ])
+
+    QT6_VALIDATE_MOC(MOC6)
+    if test x$MOC6 = x; then
+        compile_liblightdm_qt6=no
+        if test "x$enable_liblightdm_qt6" != xauto; then
+            AC_MSG_FAILURE(
+              [--enable-liblightdm-qt6 was given, but MOC not found])
+        fi
+    fi
+fi
+AM_CONDITIONAL(COMPILE_LIBLIGHTDM_QT6, test x"$compile_liblightdm_qt6" != "xno")
 
 AC_ARG_ENABLE([libaudit],
     AS_HELP_STRING([--enable-libaudit],
@@ -212,6 +241,7 @@ liblightdm-gobject/liblightdm-gobject-1.pc
 liblightdm-gobject/Makefile
 liblightdm-qt/Makefile
 liblightdm-qt/liblightdm-qt5-3.pc
+liblightdm-qt/liblightdm-qt6-3.pc
 po/Makefile.in
 src/Makefile
 tests/Makefile
@@ -237,6 +267,7 @@ echo "
         GObject introspection:    $found_introspection
         Vala bindings:            $enable_vala
         liblightdm-qt5:           $compile_liblightdm_qt5
+        liblightdm-qt6:           $compile_liblightdm_qt6
         libaudit support:         $use_libaudit
         Enable tests:             $enable_tests
 "

--- a/liblightdm-qt/Makefile.am
+++ b/liblightdm-qt/Makefile.am
@@ -4,6 +4,9 @@ common_libadd = \
 liblightdm_qt5_3_la_LIBADD = \
 	$(LIBLIGHTDM_QT5_LIBS) \
 	$(common_libadd)
+liblightdm_qt6_3_la_LIBADD = \
+	$(LIBLIGHTDM_QT6_LIBS) \
+	$(common_libadd)
 
 common_cflags = \
 	$(WARN_CXXFLAGS) \
@@ -14,6 +17,11 @@ liblightdm_qt5_3_la_CXXFLAGS = \
 	-fPIC \
 	-DQT_DISABLE_DEPRECATED_BEFORE="QT_VERSION_CHECK(4, 0, 0)" \
 	$(LIBLIGHTDM_QT5_CFLAGS) \
+	$(common_cflags)
+liblightdm_qt6_3_la_CXXFLAGS = \
+	-fPIC \
+	-DQT_DISABLE_DEPRECATED_BEFORE="QT_VERSION_CHECK(5, 0, 0)" \
+	$(LIBLIGHTDM_QT6_CFLAGS) \
 	$(common_cflags)
 
 common_headers = \
@@ -27,6 +35,7 @@ common_headers = \
 	QLightDM/usersmodel.h
 
 liblightdm_qt5_3includedir=$(includedir)/lightdm-qt5-3/QLightDM
+liblightdm_qt6_3includedir=$(includedir)/lightdm-qt6-3/QLightDM
 
 common_sources = \
 	greeter.cpp \
@@ -36,6 +45,9 @@ common_sources = \
 liblightdm_qt5_3_la_SOURCES = \
 	$(common_sources) \
 	$(liblightdm_qt5_3include_HEADERS)
+liblightdm_qt6_3_la_SOURCES = \
+	$(common_sources) \
+	$(liblightdm_qt6_3include_HEADERS)
 
 pkgconfigdir = $(libdir)/pkgconfig
 
@@ -56,9 +68,20 @@ BUILT_SOURCES += $(common_sources:.cpp=_moc5.cpp)
 pkgconfig_DATA += liblightdm-qt5-3.pc
 endif
 
+if COMPILE_LIBLIGHTDM_QT6
+lib_LTLIBRARIES += liblightdm-qt6-3.la
+liblightdm_qt6_3include_HEADERS = $(common_headers)
+BUILT_SOURCES += $(common_sources:.cpp=_moc6.cpp)
+pkgconfig_DATA += liblightdm-qt6-3.pc
+endif
+
 # Support pretty printing MOC
 AM_V_MOC5 = $(am__v_MOC5_$(V))
 am__v_MOC5_ = $(am__v_MOC5_$(AM_DEFAULT_VERBOSITY))
 am__v_MOC5_0 = @echo "  MOC5    " $@;
 %_moc5.cpp: QLightDM/%.h
 	$(AM_V_MOC5) $(MOC5) $< -o $@
+
+# qt6
+%_moc6.cpp: QLightDM/%.h
+	$(MOC6) $< -o $@

--- a/liblightdm-qt/greeter.cpp
+++ b/liblightdm-qt/greeter.cpp
@@ -328,8 +328,8 @@ QString Greeter::motd() const
     return QString::fromUtf8(lightdm_get_motd());
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-#include "greeter_moc5.cpp"
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include "greeter_moc6.cpp"
 #else
-#include "greeter_moc4.cpp"
+#include "greeter_moc5.cpp"
 #endif

--- a/liblightdm-qt/liblightdm-qt6-3.pc.in
+++ b/liblightdm-qt/liblightdm-qt6-3.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: liblightdm-qt6
+Description: LightDM Qt6 client library
+Version: @VERSION@
+Requires: Qt6Core Qt6Gui Qt6DBus
+Libs: -L${libdir} -llightdm-qt6-3
+Cflags: -I${includedir}/lightdm-qt6-3

--- a/liblightdm-qt/power.cpp
+++ b/liblightdm-qt/power.cpp
@@ -78,8 +78,8 @@ bool PowerInterface::restart()
     return lightdm_restart (NULL);
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-#include "power_moc5.cpp"
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include "power_moc6.cpp"
 #else
-#include "power_moc4.cpp"
+#include "power_moc5.cpp"
 #endif

--- a/liblightdm-qt/sessionsmodel.cpp
+++ b/liblightdm-qt/sessionsmodel.cpp
@@ -151,8 +151,8 @@ QVariant SessionsModel::data(const QModelIndex &index, int role) const
     return QVariant();
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-#include "sessionsmodel_moc5.cpp"
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include "sessionsmodel_moc6.cpp"
 #else
-#include "sessionsmodel_moc4.cpp"
+#include "sessionsmodel_moc5.cpp"
 #endif

--- a/liblightdm-qt/usersmodel.cpp
+++ b/liblightdm-qt/usersmodel.cpp
@@ -263,8 +263,8 @@ QVariant UsersModel::data(const QModelIndex &index, int role) const
 }
 
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-#include "usersmodel_moc5.cpp"
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include "usersmodel_moc6.cpp"
 #else
-#include "usersmodel_moc4.cpp"
+#include "usersmodel_moc5.cpp"
 #endif

--- a/m4/qt-validate-moc.m4
+++ b/m4/qt-validate-moc.m4
@@ -1,0 +1,68 @@
+# Detect Qt5 and Qt6 moc executable
+# partially borrowed from freeciv qt m4 scripts
+
+dnl Qt5
+AC_DEFUN([QT5_IF_QT5_MOC],
+    AS_IF([$1 -v >/dev/null 2>/dev/null &&
+        (test "`$1 -v 2<&1 | grep -o 'Qt [[[0-9]]]\+'`" = "Qt 5" ||
+         test "`$1 -v 2<&1 | grep -o 'moc [[[0-9]]]\+'`" = "moc 5" ||
+         test "`$1 -v 2<&1 | grep -o 'moc-qt[[[0-9]]]\+'`" = "moc-qt5")],
+        [$2]))
+
+dnl Set MOCCMD to $1 if it is the Qt 5 "moc".
+AC_DEFUN([QT5_TRY_MOC],
+    [QT5_IF_QT5_MOC([$1], [MOCCMD="$1"])])
+
+dnl If a usable moc command is found set $1
+AC_DEFUN([QT5_VALIDATE_MOC], [
+    AC_MSG_CHECKING([the Qt 5 moc command])
+
+    dnl Try to find a Qt 5 'moc'
+    AS_IF([test "x$MOCCMD" = "x"],
+        [for mocpath in "moc" "qtchooser -run-tool=moc -qt=5" "moc-qt5"
+        do
+            if test "x$MOCCMD" = "x" ; then
+                QT5_TRY_MOC([$mocpath])
+            fi
+        done
+        AS_IF([test "x$MOCCMD" = "x"],
+            [AC_MSG_RESULT([not found]); AC_SUBST($1,"")],
+            [AC_MSG_RESULT([$MOCCMD]); AC_SUBST($1,"$MOCCMD")])
+        MOCCMD=""],
+        [AC_MSG_ERROR(["MOCCMD should not be set"])])])
+
+
+dnl Qt6
+AC_DEFUN([QT6_IF_QT6_MOC],
+    AS_IF([$1 -v >/dev/null 2>/dev/null &&
+        (test "`$1 -v 2<&1 | grep -o 'Qt [[[0-9]]]\+'`" = "Qt 6" ||
+         test "`$1 -v 2<&1 | grep -o 'moc [[[0-9]]]\+'`" = "moc 6" ||
+         test "`$1 -v 2<&1 | grep -o 'moc-qt[[[0-9]]]\+'`" = "moc-qt6")],
+        [$2]))
+
+dnl Set MOCCMD to $1 if it is the Qt 6 "moc".
+AC_DEFUN([QT6_TRY_MOC],
+    [QT6_IF_QT6_MOC([$1], [MOCCMD="$1"])])
+
+dnl If a usable moc command is found set $1
+AC_DEFUN([QT6_VALIDATE_MOC], [
+    AC_MSG_CHECKING([the Qt 6 moc command])
+
+    dnl Try to find a Qt 6 'moc'
+    AS_IF([test "x$MOCCMD" = "x"],
+        [for mocpath in "moc" "qtchooser -run-tool=moc -qt=6" "moc-qt6" \
+                        "/usr/lib/qt6/moc" "/usr/lib/qt6/libexec/moc" \
+                        "/usr/lib64/qt6/moc" "/usr/lib64/qt6/libexec/moc" \
+                        "$prefix/lib/qt6/moc" "$prefix/lib/qt6/libexec/moc" \
+                        "$libexecdir/moc" "$libexecdir/qt6/moc" \
+                        "$libdir/qt6/moc" "$libdir/qt6/libexec/moc"
+        do
+            if test "x$MOCCMD" = "x" ; then
+                QT6_TRY_MOC([$mocpath])
+            fi
+        done
+        AS_IF([test "x$MOCCMD" = "x"],
+            [AC_MSG_RESULT([not found]); AC_SUBST($1,"")],
+            [AC_MSG_RESULT([$MOCCMD]); AC_SUBST($1,"$MOCCMD")])
+        MOCCMD=""],
+        [AC_MSG_ERROR(["MOCCMD should not be set"])])])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -336,6 +336,42 @@ TESTS += \
 	test-power-qt5
 endif
 
+if COMPILE_LIBLIGHTDM_QT6
+TESTS += \
+	test-autologin-timeout-qt6 \
+	test-autologin-guest-timeout-qt6 \
+	test-autologin-session-timeout-qt6 \
+	test-cancel-authentication-qt6 \
+	test-login-qt6 \
+	test-login-manual-qt6 \
+	test-login-manual-previous-session-qt6 \
+	test-login-no-password-qt6 \
+	test-login-long-username-qt6 \
+	test-login-long-password-qt6 \
+	test-login-two-factor-qt6 \
+	test-login-new-authtok-qt6 \
+	test-login-info-prompt-qt6 \
+	test-login-multi-info-prompt-qt6 \
+	test-login-previous-session-qt6 \
+	test-login-wrong-password-qt6 \
+	test-login-invalid-user-qt6 \
+	test-login-invalid-session-qt6 \
+	test-login-logout-qt6 \
+	test-login-pick-session-qt6 \
+	test-login-remember-session-qt6 \
+	test-login-manual-remember-session-qt6 \
+	test-login-guest-qt6 \
+	test-login-guest-pick-session-qt6 \
+	test-login-guest-disabled-qt6 \
+	test-login-guest-no-setup-script-qt6 \
+	test-login-guest-fail-setup-script-qt6 \
+	test-login-guest-logout-qt6 \
+	test-login-remote-session-qt6 \
+	test-sessions-qt6 \
+	test-users-qt6 \
+	test-power-qt6
+endif
+
 EXTRA_DIST = \
 	$(TESTS) \
 	data/remote-sessions/test-remote.desktop \
@@ -345,6 +381,7 @@ EXTRA_DIST = \
 	data/greeters/test-mir-greeter.desktop \
 	data/greeters/test-python-greeter.desktop \
 	data/greeters/test-qt5-greeter.desktop \
+	data/greeters/test-qt6-greeter.desktop \
 	data/greeters/test-wayland-greeter.desktop \
 	data/keys.conf \
 	data/sessions/alternative.desktop \

--- a/tests/data/greeters/test-qt6-greeter.desktop
+++ b/tests/data/greeters/test-qt6-greeter.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Name=Test Qt6 Greeter
+Comment=LightDM test Qt6 greeter
+Exec=test-qt6-greeter

--- a/tests/src/Makefile.am
+++ b/tests/src/Makefile.am
@@ -40,6 +40,10 @@ if COMPILE_LIBLIGHTDM_QT5
 noinst_PROGRAMS += test-qt5-greeter
 endif
 
+if COMPILE_LIBLIGHTDM_QT6
+noinst_PROGRAMS += test-qt6-greeter
+endif
+
 dbus_env_CFLAGS = \
 	$(WARN_CFLAGS) \
 	$(GLIB_CFLAGS) \
@@ -139,23 +143,32 @@ test_script_hook_LDADD = \
 
 test-qt5-greeter_moc5.cpp: test-qt-greeter.h
 	$(am__v_MOC5_$(V)) $(MOC5) $< -o $@
+test-qt6-greeter_moc6.cpp: test-qt-greeter.h
+	$(MOC6) $< -o $@
 common_qt_sources = test-qt-greeter.cpp test-qt-greeter.h status.c status.h
 test_qt5_greeter_SOURCES = $(common_qt_sources)
+test_qt6_greeter_SOURCES = $(common_qt_sources)
 nodist_test_qt5_greeter_SOURCES = test-qt5-greeter_moc5.cpp
+nodist_test_qt6_greeter_SOURCES = test-qt6-greeter_moc6.cpp
 common_qt_cflags = \
 	$(WARN_CXXFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(GIO_UNIX_CFLAGS) \
 	$(XCB_CFLAGS)
 test_qt5_greeter_CFLAGS = $(common_qt_cflags)
+test_qt6_greeter_CFLAGS = $(common_qt_cflags)
 common_qt_cxxflags = \
 	-fPIC \
-	-DQT_DISABLE_DEPRECATED_BEFORE="QT_VERSION_CHECK(4, 0, 0)" \
 	-I$(top_srcdir)/liblightdm-qt \
 	$(GLIB_CFLAGS)
 test_qt5_greeter_CXXFLAGS = \
 	$(common_qt_cxxflags) \
+	-DQT_DISABLE_DEPRECATED_BEFORE="QT_VERSION_CHECK(4, 0, 0)" \
 	$(LIBLIGHTDM_QT5_CFLAGS)
+test_qt6_greeter_CXXFLAGS = \
+	$(common_qt_cxxflags) \
+	-DQT_DISABLE_DEPRECATED_BEFORE="QT_VERSION_CHECK(5, 0, 0)" \
+	$(LIBLIGHTDM_QT6_CFLAGS)
 common_qt_ldadd = \
 	-L$(top_builddir)/liblightdm-gobject \
 	-llightdm-gobject-1 \
@@ -167,6 +180,10 @@ test_qt5_greeter_LDADD = \
 	$(common_qt_ldadd) \
 	-llightdm-qt5-3 \
 	$(LIBLIGHTDM_QT5_LIBS)
+test_qt6_greeter_LDADD = \
+	$(common_qt_ldadd) \
+	-llightdm-qt6-3 \
+	$(LIBLIGHTDM_QT6_LIBS)
 
 test_session_SOURCES = test-session.c status.c status.h
 test_session_CFLAGS = \
@@ -212,7 +229,8 @@ vnc_client_LDADD = \
 	$(GIO_UNIX_LIBS)
 
 CLEANFILES = \
-	test-qt5-greeter_moc5.cpp
+	test-qt5-greeter_moc5.cpp \
+	test-qt6-greeter_moc6.cpp
 
 # Support pretty printing MOC
 AM_V_MOC5 = $(am__v_MOC5_$(V))

--- a/tests/src/test-qt-greeter.cpp
+++ b/tests/src/test-qt-greeter.cpp
@@ -34,12 +34,12 @@ TestGreeter::TestGreeter ()
 
 void TestGreeter::showMessage (QString text, QLightDM::Greeter::MessageType type)
 {
-    status_notify ("%s SHOW-MESSAGE TEXT=\"%s\"", greeter_id, text.toAscii ().constData ());
+    status_notify ("%s SHOW-MESSAGE TEXT=\"%s\"", greeter_id, text.toLatin1 ().constData ());
 }
 
 void TestGreeter::showPrompt (QString text, QLightDM::Greeter::PromptType type)
 {
-    status_notify ("%s SHOW-PROMPT TEXT=\"%s\"", greeter_id, text.toAscii ().constData ());
+    status_notify ("%s SHOW-PROMPT TEXT=\"%s\"", greeter_id, text.toLatin1 ().constData ());
 }
 
 void TestGreeter::authenticationComplete ()
@@ -47,7 +47,7 @@ void TestGreeter::authenticationComplete ()
     if (authenticationUser () != "")
         status_notify ("%s AUTHENTICATION-COMPLETE USERNAME=%s AUTHENTICATED=%s",
                        greeter_id,
-                       authenticationUser ().toAscii ().constData (), isAuthenticated () ? "TRUE" : "FALSE");
+                       authenticationUser ().toLatin1 ().constData (), isAuthenticated () ? "TRUE" : "FALSE");
     else
         status_notify ("%s AUTHENTICATION-COMPLETE AUTHENTICATED=%s", greeter_id, isAuthenticated () ? "TRUE" : "FALSE");
 }
@@ -59,7 +59,7 @@ void TestGreeter::autologinTimerExpired ()
 void TestGreeter::printHints ()
 {
     if (selectUserHint() != "")
-        status_notify ("%s SELECT-USER-HINT USERNAME=%s", greeter_id, greeter->selectUserHint ().toAscii ().constData ());
+        status_notify ("%s SELECT-USER-HINT USERNAME=%s", greeter_id, greeter->selectUserHint ().toLatin1 ().constData ());
     if (selectGuestHint())
         status_notify ("%s SELECT-GUEST-HINT", greeter_id);
     if (lockHint())
@@ -73,11 +73,11 @@ void TestGreeter::printHints ()
     if (!showRemoteLoginHint ())
         status_notify ("%s SHOW-REMOTE-LOGIN-HINT=FALSE", greeter_id);
     if (autologinUserHint () != "")
-        status_notify ("%s AUTOLOGIN-USER-HINT=%s", greeter_id, autologinUserHint ().toAscii ().constData ());
+        status_notify ("%s AUTOLOGIN-USER-HINT=%s", greeter_id, autologinUserHint ().toLatin1 ().constData ());
     if (autologinGuestHint ())
         status_notify ("%s AUTOLOGIN-GUEST-HINT", greeter_id);
     if (autologinSessionHint () != "")
-        status_notify ("%s AUTOLOGIN-SESSION-HINT=%s", greeter_id, autologinSessionHint ().toAscii ().constData ());
+        status_notify ("%s AUTOLOGIN-SESSION-HINT=%s", greeter_id, autologinSessionHint ().toLatin1 ().constData ());
     if (autologinTimeoutHint () != 0)
         status_notify ("%s AUTOLOGIN-TIMEOUT-HINT=%d", greeter_id, autologinTimeoutHint ());
 }

--- a/tests/test-autologin-guest-timeout-qt6
+++ b/tests/test-autologin-guest-timeout-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner autologin-guest-timeout test-qt6-greeter

--- a/tests/test-autologin-session-timeout-qt6
+++ b/tests/test-autologin-session-timeout-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner autologin-session-timeout test-qt6-greeter

--- a/tests/test-autologin-timeout-qt6
+++ b/tests/test-autologin-timeout-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner autologin-timeout test-qt6-greeter

--- a/tests/test-cancel-authentication-qt6
+++ b/tests/test-cancel-authentication-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner cancel-authentication test-qt6-greeter

--- a/tests/test-login-guest-disabled-qt6
+++ b/tests/test-login-guest-disabled-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-guest-disabled test-qt6-greeter

--- a/tests/test-login-guest-fail-setup-script-qt6
+++ b/tests/test-login-guest-fail-setup-script-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-guest-fail-setup-script test-qt6-greeter

--- a/tests/test-login-guest-logout-qt6
+++ b/tests/test-login-guest-logout-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-guest-logout test-qt6-greeter

--- a/tests/test-login-guest-no-setup-script-qt6
+++ b/tests/test-login-guest-no-setup-script-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-guest-no-setup-script test-qt6-greeter

--- a/tests/test-login-guest-pick-session-qt6
+++ b/tests/test-login-guest-pick-session-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-guest-pick-session test-qt6-greeter

--- a/tests/test-login-guest-qt6
+++ b/tests/test-login-guest-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-guest test-qt6-greeter

--- a/tests/test-login-info-prompt-qt6
+++ b/tests/test-login-info-prompt-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-info-prompt test-qt6-greeter

--- a/tests/test-login-invalid-session-qt6
+++ b/tests/test-login-invalid-session-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-invalid-session test-qt6-greeter

--- a/tests/test-login-invalid-user-qt6
+++ b/tests/test-login-invalid-user-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-invalid-user test-qt6-greeter

--- a/tests/test-login-logout-qt6
+++ b/tests/test-login-logout-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-logout test-qt6-greeter

--- a/tests/test-login-long-password-qt6
+++ b/tests/test-login-long-password-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-long-password test-qt6-greeter

--- a/tests/test-login-long-username-qt6
+++ b/tests/test-login-long-username-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-long-username test-qt6-greeter

--- a/tests/test-login-manual-previous-session-qt6
+++ b/tests/test-login-manual-previous-session-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-manual-previous-session test-qt6-greeter

--- a/tests/test-login-manual-qt6
+++ b/tests/test-login-manual-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-manual test-qt6-greeter

--- a/tests/test-login-manual-remember-session-qt6
+++ b/tests/test-login-manual-remember-session-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-manual-remember-session test-qt6-greeter

--- a/tests/test-login-multi-info-prompt-qt6
+++ b/tests/test-login-multi-info-prompt-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-multi-info-prompt test-qt6-greeter

--- a/tests/test-login-new-authtok-qt6
+++ b/tests/test-login-new-authtok-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-new-authtok test-qt6-greeter

--- a/tests/test-login-no-password-qt6
+++ b/tests/test-login-no-password-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-no-password test-qt6-greeter

--- a/tests/test-login-pick-session-qt6
+++ b/tests/test-login-pick-session-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-pick-session test-qt6-greeter

--- a/tests/test-login-previous-session-qt6
+++ b/tests/test-login-previous-session-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-previous-session test-qt6-greeter

--- a/tests/test-login-qt6
+++ b/tests/test-login-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login test-qt6-greeter

--- a/tests/test-login-remember-session-qt6
+++ b/tests/test-login-remember-session-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-remember-session test-qt6-greeter

--- a/tests/test-login-remote-session-qt6
+++ b/tests/test-login-remote-session-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-remote-session test-qt6-greeter

--- a/tests/test-login-two-factor-qt6
+++ b/tests/test-login-two-factor-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-two-factor test-qt6-greeter

--- a/tests/test-login-wrong-password-qt6
+++ b/tests/test-login-wrong-password-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner login-wrong-password test-qt6-greeter

--- a/tests/test-power-qt6
+++ b/tests/test-power-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner power test-qt6-greeter

--- a/tests/test-sessions-qt6
+++ b/tests/test-sessions-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner sessions test-qt6-greeter

--- a/tests/test-users-qt6
+++ b/tests/test-users-qt6
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner users test-qt6-greeter


### PR DESCRIPTION
I would like to port `lightdm-kde-greeter` to qt6, and this requires the corresponding lightdm library.

I did not delete the version for qt5, the versions do not interfere with each other. The source code has not changed much, just updated the outdated `QString::toAscii` method.

Added an m4 macro to search for the `moc` executable file to check the version. It seems that this will be more reliable if there are several of them in the system. For reference, I used macros from the `freeciv` project. ([qt6.m4](https://github.com/freeciv/freeciv/blob/main/m4/qt6.m4))