### PR TITLE
debian: Drop ExecPreStart hack

### DIFF
--- a/debian/lightdm.service
+++ b/debian/lightdm.service
@@ -8,9 +8,6 @@ StartLimitBurst=5
 OnFailure=lightdm-failure-handler.service
 
 [Service]
-# temporary safety check until all DMs are converted to correct
-# display-manager.service symlink handling
-ExecStartPre=/bin/sh -c '[ "$(basename $(cat /etc/X11/default-display-manager 2>/dev/null))" = "lightdm" ]'
 ExecStart=/usr/sbin/lightdm
 Restart=always
 RestartSec=5s


### PR DESCRIPTION
All the other display managers have been migrated since a while now.