### PR TITLE
Allow users to set location of .xsession-errors

### DIFF
--- a/common/configuration.c
+++ b/common/configuration.c
@@ -346,6 +346,7 @@ config_init (Configuration *config)
     g_hash_table_insert (config->priv->lightdm_keys, "greeters-directory", GINT_TO_POINTER (KEY_SUPPORTED));
     g_hash_table_insert (config->priv->lightdm_keys, "backup-logs", GINT_TO_POINTER (KEY_SUPPORTED));
     g_hash_table_insert (config->priv->lightdm_keys, "dbus-service", GINT_TO_POINTER (KEY_SUPPORTED));
+    g_hash_table_insert (config->priv->lightdm_keys, "xsession-errors-path", GINT_TO_POINTER (KEY_SUPPORTED));
     g_hash_table_insert (config->priv->lightdm_keys, "logind-load-seats", GINT_TO_POINTER (KEY_DEPRECATED));
 
     g_hash_table_insert (config->priv->seat_keys, "type", GINT_TO_POINTER (KEY_SUPPORTED));

--- a/data/lightdm.conf
+++ b/data/lightdm.conf
@@ -17,6 +17,7 @@
 # greeters-directory = Directory to find greeters
 # backup-logs = True to move add a .old suffix to old log files when opening new ones
 # dbus-service = True if LightDM provides a D-Bus service to control it
+# xsession-errors-path = Log file for X session errors, relative to $HOME. Supports environment expansion.
 #
 [LightDM]
 #start-default-seat=true
@@ -35,6 +36,7 @@
 #greeters-directory=$XDG_DATA_DIRS/lightdm/greeters:$XDG_DATA_DIRS/xgreeters
 #backup-logs=true
 #dbus-service=true
+#xsession-errors-path=.xsession-errors
 
 #
 # Seat configuration

--- a/src/lightdm.c
+++ b/src/lightdm.c
@@ -773,6 +773,8 @@ main (int argc, char **argv)
         config_set_boolean (config_get_instance (), "LightDM", "backup-logs", TRUE);
     if (!config_has_key (config_get_instance (), "LightDM", "dbus-service"))
         config_set_boolean (config_get_instance (), "LightDM", "dbus-service", TRUE);
+    if (!config_has_key (config_get_instance (), "LightDM", "xsession-errors-path"))
+        config_set_string (config_get_instance (), "LightDM", "xsession-errors-path", ".xsession-errors");
     if (!config_has_key (config_get_instance (), "Seat:*", "type"))
         config_set_string (config_get_instance (), "Seat:*", "type", "local");
     if (!config_has_key (config_get_instance (), "Seat:*", "pam-service"))


### PR DESCRIPTION
A more flexible approach to #335 that allows users to set the .xsession-errors path directly. Supports shell expansion in the forms $VAR and ${VAR}.

Someone more experienced with glib should look it over. I'm not certain I've got the pointer semantics right. The GRegex object should probably be static, too.