### PR TITLE
Set greeter_session instead of session when reconfiguring the display…

### DIFF
--- a/src/seat.c
+++ b/src/seat.c
@@ -620,8 +620,8 @@ switch_to_greeter_from_failed_session (Seat *seat, Session *session)
             session_set_display_server (SESSION (greeter_session), session_get_display_server (session));
         else
         {
-            DisplayServer *display_server = create_display_server (seat, session);
-            session_set_display_server (session, display_server);
+            DisplayServer *display_server = create_display_server (seat, greeter_session);
+            session_set_display_server (greeter_session, display_server);
             if (!start_display_server (seat, display_server))
             {
                 l_debug (seat, "Failed to start display server for greeter");


### PR DESCRIPTION
…_server after a session startup failure

When using a Wayland desktop environment with auto-login enabled, if the account password has expired, the auto-login process fails due to password expiration. This results in a black screen with no functional login interface. I traced the issue to the switch_to_greeter_from_failed_session function and discovered that the display_server was still configured to use the original session type (session) during reinitialization. After modifying the session type to greeter_session, the problem was resolved. This fix ensures the display server correctly triggers the login manager (greeter) when handling authentication failures.