### PR TITLE
fix(login session): Fixed User desktop login failure after the .Xauth…

### DIFF
--- a/src/x-authority.c
+++ b/src/x-authority.c
@@ -294,7 +294,8 @@ x_authority_write (XAuthority *auth, XAuthWriteMode mode, const gchar *filename,
         if (!matched &&
             priv->family == a_priv->family &&
             address_matches &&
-            strcmp (priv->number, a_priv->number) == 0)
+            strcmp (priv->number, a_priv->number) == 0 &&
+            strcmp (priv->authorization_name, a_priv->authorization_name) == 0)
         {
             matched = TRUE;
             if (mode == XAUTH_WRITE_MODE_REMOVE)


### PR DESCRIPTION
…ority file's authname is modified

Description: 修复用户的.Xauthority文件的authname被修改后无法登录用户桌面问题

Log: null