### PR TITLE
Fix PAM session termination in child process to support deferred pam_cap operations

### DIFF
--- a/src/session-child.c
+++ b/src/session-child.c
@@ -656,14 +656,14 @@ session_child_run (int argc, char **argv)
         if (setsid () < 0)
             _exit (errno);
 
+        extern char **environ;
+        environ = pam_getenvlist (pam_handle);
 #if HAVE_SETUSERCONTEXT
         /* Setup user context
         * Reset the current environment to what is in the PAM context,
         * then setusercontext will add to it as necessary as there is no
         * option for setusercontext to add to a PAM context.
         */
-        extern char **environ;
-        environ = pam_getenvlist (pam_handle);
         struct passwd* pwd = getpwnam (username);
         if (pwd) {
             if (setusercontext (NULL, pwd, pwd->pw_uid, LOGIN_SETALL) < 0) {
@@ -711,14 +711,12 @@ session_child_run (int argc, char **argv)
         /* Reset SIGPIPE handler so the child has default behaviour (we disabled it at LightDM start) */
         signal (SIGPIPE, SIG_DFL);
 
+        /* End PAM session with DATA_SILENT
+         * To notify PAM modules (e.g. pam_cap) of transaction termination */
+        (void) pam_end(pam_handle, PAM_SUCCESS | PAM_DATA_SILENT);
+
         /* Run the command */
-        execve (command_argv[0], command_argv,
-#if HAVE_SETUSERCONTEXT
-            environ
-#else
-            pam_getenvlist (pam_handle)
-#endif
-        );
+        execve (command_argv[0], command_argv, environ);
         _exit (EXIT_FAILURE);
     }
 


### PR DESCRIPTION
The pam_cap.so module with the `defer` option fails to apply capabilities correctly when logging in through LightDM. While the configuration works with text-based login (as fixed in shadow-maint/shadow#408), LightDM doesn't properly terminate the PAM session in the child process, preventing deferred capability assignment from taking effect during graphical login sessions.

#### Example Configuration:

```
# /etc/pam.d/lightdm
auth       optional     pam_cap.so keepcaps defer
```

#### Background:

- Without `defer`: pam_cap sets capabilities through pam_setcred()
- With `defer`: pam_cap relies on [pam_end()](https://man7.org/linux/man-pages/man3/pam_end.3.html) to finalize capability assignment

#### Comparison with GDM:

Works correctly with pam_cap because it properly calls `pam_setcred()` after `setuid()`. This correct behavior means the `defer` option is **​​not required​​** for GDM to function with pam_cap.