### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload Test Log
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Log ${{ matrix.image.name }} ${{ matrix.image.tag }}
           path: tests/test-suite.log

--- a/src/lightdm.c
+++ b/src/lightdm.c
@@ -26,6 +26,7 @@
 #include "display-manager-service.h"
 #include "xdmcp-server.h"
 #include "vnc-server.h"
+#include "vt.h"
 #include "seat-xdmcp-session.h"
 #include "seat-xvnc.h"
 #include "x-server.h"
@@ -918,6 +919,10 @@ main (int argc, char **argv)
             {
                 set_seat_properties (seat, NULL);
                 seat_set_property (seat, "exit-on-failure", "true");
+
+                /* in the absence of login1 we find out this using our own heuristics */
+                seat_set_can_tty (seat, vt_can_multi_seat ());
+
                 if (!display_manager_add_seat (display_manager, seat))
                     return EXIT_FAILURE;
             }

--- a/tests/src/test-runner.c
+++ b/tests/src/test-runner.c
@@ -128,6 +128,7 @@ typedef struct
     gchar *path;
     gboolean can_graphical;
     gboolean can_multi_session;
+    gboolean can_tty;
     gchar *active_session;
 } Login1Seat;
 
@@ -1555,6 +1556,8 @@ handle_login1_seat_get_property (GDBusConnection       *connection,
         return g_variant_new_boolean (seat->can_graphical);
     else if (strcmp (property_name, "CanMultiSession") == 0)
         return g_variant_new_boolean (seat->can_multi_session);
+    else if (strcmp (property_name, "CanTTY") == 0)
+        return g_variant_new_boolean (seat->can_tty);
     else if (strcmp (property_name, "Id") == 0)
         return g_variant_new_string (seat->id);
     else if (strcmp (property_name, "ActiveSession") == 0)
@@ -1580,6 +1583,7 @@ add_login1_seat (GDBusConnection *connection, const gchar *id, gboolean emit_sig
     seat->path = g_strdup_printf ("/org/freedesktop/login1/seat/%s", seat->id);
     seat->can_graphical = TRUE;
     seat->can_multi_session = TRUE;
+    seat->can_tty = TRUE;
     seat->active_session = NULL;
 
     const gchar *login1_seat_interface =
@@ -1587,6 +1591,7 @@ add_login1_seat (GDBusConnection *connection, const gchar *id, gboolean emit_sig
         "  <interface name='org.freedesktop.login1.Seat'>"
         "    <property name='CanGraphical' type='b' access='read'/>"
         "    <property name='CanMultiSession' type='b' access='read'/>"
+        "    <property name='CanTTY' type='b' access='read'/>"
         "    <property name='ActiveSession' type='(so)' access='read'/>"
         "    <property name='Id' type='s' access='read'/>"
         "  </interface>"


### PR DESCRIPTION
As far as I understand, after #315 a significant number of tests broke. This was mostly due to the fact that the `CanTTY` property introduced in the PR was not added to the test dbus interface. Also, recently the actions stopped running completely because `actions/upload-artifact@v3` was deprecated.

Updated to `actions/upload-artifact@v4` and fixed the problem with `can_tty`.