### PR TITLE
user: fix unintentional fall-through

### DIFF
--- a/liblightdm-gobject/user.c
+++ b/liblightdm-gobject/user.c
@@ -714,6 +714,7 @@ lightdm_user_get_property (GObject    *object,
         break;
     case USER_PROP_IS_LOCKED:
         g_value_set_boolean (value, lightdm_user_get_is_locked (self));
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
         break;


### PR DESCRIPTION
Fixes an issue where the warning message introduced by `G_OBJECT_WARN_INVALID_PROPERTY_ID` is shown when reading `is-locked` property.
