### PR TITLE
Deduplicate matching Xauthority records

### DIFF
--- a/src/x-authority.c
+++ b/src/x-authority.c
@@ -261,7 +261,7 @@ x_authority_write (XAuthority *auth, XAuthWriteMode mode, const gchar *filename,
             g_warning ("Error reading existing Xauthority: %s", read_error->message);
     }
     GList *records = NULL;
-    gboolean matched = FALSE;
+    gboolean matching_record_found = FALSE;
     while (input_offset != input_length)
     {
         g_autoptr(XAuthority) a = g_object_new (X_AUTHORITY_TYPE, NULL);
@@ -290,24 +290,28 @@ x_authority_write (XAuthority *auth, XAuthWriteMode mode, const gchar *filename,
             address_matches = i == priv->address_length;
         }
 
-        /* If this record matches, then update or delete it */
-        if (!matched &&
-            priv->family == a_priv->family &&
-            address_matches &&
-            strcmp (priv->number, a_priv->number) == 0)
+        gboolean record_matches = priv->family == a_priv->family &&
+                                  address_matches &&
+                                  strcmp (priv->number, a_priv->number) == 0 &&
+                                  strcmp (priv->authorization_name, a_priv->authorization_name) == 0;
+
+        /* Remove all matching records, or update and keep only the first one */
+        if (record_matches)
         {
-            matched = TRUE;
-            if (mode == XAUTH_WRITE_MODE_REMOVE)
+            gboolean duplicate_record = matching_record_found;
+            matching_record_found = TRUE;
+
+            if (mode == XAUTH_WRITE_MODE_REMOVE || duplicate_record)
                 continue;
-            else
-                x_authority_set_authorization_data (a, priv->authorization_data, priv->authorization_data_length);
+
+            x_authority_set_authorization_data (a, priv->authorization_data, priv->authorization_data_length);
         }
 
         records = g_list_append (records, g_steal_pointer (&a));
     }
 
-    /* If didn't exist, then add a new one */
-    if (!matched)
+    /* If setting or replacing a missing record, then add a new one */
+    if (mode != XAUTH_WRITE_MODE_REMOVE && !matching_record_found)
         records = g_list_append (records, g_object_ref (auth));
 
     /* Write records back */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -72,6 +72,7 @@ TESTS = \
 	test-session-stderr-backup \
 	test-xauthority \
 	test-corrupt-xauthority \
+	test-stale-xauthority \
 	test-system-xauthority \
 	test-sessions-gobject \
 	test-user-renamed \
@@ -395,6 +396,7 @@ EXTRA_DIST = \
 	scripts/console-kit.conf \
 	scripts/console-kit-no-xdg-runtime.conf \
 	scripts/corrupt-xauthority.conf \
+	scripts/stale-xauthority.conf \
 	scripts/crash-authenticate.conf \
 	scripts/cred-error.conf \
 	scripts/cred-expired.conf \

--- a/tests/scripts/stale-xauthority.conf
+++ b/tests/scripts/stale-xauthority.conf
@@ -1,0 +1,40 @@
+#
+# Check stale X authority records are replaced on login
+#
+
+[Seat:*]
+autologin-user=stale-xauth
+user-session=default
+
+#?*START-DAEMON
+#?RUNNER DAEMON-START
+
+# X server starts
+#?XSERVER-0 START VT=7 SEAT=seat0
+
+# Daemon connects when X server is ready
+#?*XSERVER-0 INDICATE-READY
+#?XSERVER-0 INDICATE-READY
+#?XSERVER-0 ACCEPT-CONNECT
+
+# Session starts
+#?SESSION-X-0 START XDG_SEAT=seat0 XDG_VTNR=7 XDG_GREETER_DATA_DIR=.*/stale-xauth XDG_SESSION_TYPE=x11 XDG_SESSION_DESKTOP=default USER=stale-xauth
+#?LOGIN1 ACTIVATE-SESSION SESSION=c0
+#?XSERVER-0 ACCEPT-CONNECT
+#?SESSION-X-0 CONNECT-XSERVER
+
+# Check where the X authority is
+#?*SESSION-X-0 READ-ENV NAME=XAUTHORITY
+#?SESSION-X-0 READ-ENV NAME=XAUTHORITY VALUE=.*/home/stale-xauth/.Xauthority
+
+# Check duplicate cookies for the current display are replaced, while other entries remain
+#?*SESSION-X-0 CHECK-X-AUTHORITY
+#?SESSION-X-0 CHECK-X-AUTHORITY MODE=rw-------
+#?*SESSION-X-0 CHECK-X-AUTHORITY-RECORDS
+#?SESSION-X-0 CHECK-X-AUTHORITY-RECORDS RECORDS=2 MATCHING=1 STALE=0 UNRELATED=1
+
+# Cleanup
+#?*STOP-DAEMON
+#?SESSION-X-0 TERMINATE SIGNAL=15
+#?XSERVER-0 TERMINATE SIGNAL=15
+#?RUNNER DAEMON-EXIT STATUS=0

--- a/tests/src/Makefile.am
+++ b/tests/src/Makefile.am
@@ -15,6 +15,8 @@ noinst_PROGRAMS = dbus-env \
                   vnc-client \
                   X \
                   Xvnc
+check_PROGRAMS = test-x-authority-write
+TESTS = $(check_PROGRAMS)
 dist_noinst_SCRIPTS = lightdm-session \
                       test-python-greeter
 noinst_LTLIBRARIES = libsystem.la
@@ -60,6 +62,19 @@ test_runner_LDADD = \
 	$(GLIB_LIBS) \
 	$(GIO_LIBS) \
 	$(GIO_UNIX_LIBS)
+
+test_x_authority_write_SOURCES = \
+	test-x-authority-write.c \
+	$(top_srcdir)/src/x-authority.c \
+	$(top_srcdir)/src/x-authority.h
+test_x_authority_write_CFLAGS = \
+	-I$(top_srcdir)/src \
+	$(WARN_CFLAGS) \
+	$(GOBJECT_CFLAGS) \
+	$(GLIB_CFLAGS)
+test_x_authority_write_LDADD = \
+	$(GOBJECT_LIBS) \
+	$(GLIB_LIBS)
 
 X_SOURCES = X.c x-authority.c x-authority.h x-common.c x-common.h x-server.c x-server.h xdmcp-client.c xdmcp-client.h status.c status.h
 X_CFLAGS = \

--- a/tests/src/test-runner.c
+++ b/tests/src/test-runner.c
@@ -2520,6 +2520,61 @@ cp (GFile *src, GFile *dst)
         g_error ("Failed to copy %s to %s: %s", g_file_peek_path (s), g_file_peek_path (d), error->message);
 }
 
+static void
+append_card16 (GString *data, guint16 value)
+{
+    g_string_append_c (data, value >> 8);
+    g_string_append_c (data, value & 0xFF);
+}
+
+static void
+append_xauthority_data (GString *data, const guint8 *value, guint16 value_length)
+{
+    append_card16 (data, value_length);
+    g_string_append_len (data, (const gchar *) value, value_length);
+}
+
+static void
+append_xauthority_string (GString *data, const gchar *value)
+{
+    append_xauthority_data (data, (const guint8 *) value, strlen (value));
+}
+
+static void
+append_xauthority_record (GString *data, guint16 family, const gchar *address, const gchar *number, const guint8 *cookie)
+{
+    append_card16 (data, family);
+    append_xauthority_string (data, address);
+    append_xauthority_string (data, number);
+    append_xauthority_string (data, "MIT-MAGIC-COOKIE-1");
+    append_xauthority_data (data, cookie, 16);
+}
+
+static void
+write_stale_xauthority (const gchar *path)
+{
+    const guint8 stale_cookie[16] = {
+        0x00, 0x01, 0x02, 0x03,
+        0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0A, 0x0B,
+        0x0C, 0x0D, 0x0E, 0x0F
+    };
+    const guint8 other_cookie[16] = {
+        0xF0, 0xF1, 0xF2, 0xF3,
+        0xF4, 0xF5, 0xF6, 0xF7,
+        0xF8, 0xF9, 0xFA, 0xFB,
+        0xFC, 0xFD, 0xFE, 0xFF
+    };
+
+    g_autoptr(GString) data = g_string_new ("");
+    append_xauthority_record (data, 256, "lightdm-test", "0", stale_cookie);
+    append_xauthority_record (data, 256, "lightdm-test", "0", stale_cookie);
+    append_xauthority_record (data, 256, "stale-host", "9", other_cookie);
+
+    g_file_set_contents (path, data->str, data->len, NULL);
+    chmod (path, S_IRUSR | S_IWUSR);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -2779,6 +2834,8 @@ main (int argc, char **argv)
         {"prop-user",        "",          "TEST",               1033},
         /* This account has the home directory changed by PAM during authentication */
         {"change-home-dir",    "",       "Change Home Dir User", 1034},
+        /* This account has an existing stale X authority */
+        {"stale-xauth",      "password",  "Stale Xauthority",   1035},
         {NULL,               NULL,        NULL,                    0}
     };
     g_autoptr(GString) passwd_data = g_string_new ("");
@@ -2831,6 +2888,13 @@ main (int argc, char **argv)
             gchar data[1] = { 0xFF };
             g_file_set_contents (path, data, 1, NULL);
             chmod (path, S_IRUSR | S_IWUSR);
+        }
+
+        /* Write stale X authority file */
+        if (strcmp (users[i].user_name, "stale-xauth") == 0)
+        {
+            g_autofree gchar *path = g_build_filename (home_dir, users[i].user_name, ".Xauthority", NULL);
+            write_stale_xauthority (path);
         }
 
         /* Add passwd file entry */

--- a/tests/src/test-session.c
+++ b/tests/src/test-session.c
@@ -28,6 +28,123 @@ static xcb_connection_t *connection;
 static LightDMGreeter *greeter = NULL;
 
 static gboolean
+read_card16 (const guint8 *data, gsize data_length, gsize *offset, guint16 *value)
+{
+    if (*offset + 2 > data_length)
+        return FALSE;
+
+    *value = data[*offset] << 8 | data[*offset + 1];
+    *offset += 2;
+
+    return TRUE;
+}
+
+static gboolean
+read_xauthority_data (const guint8 *data, gsize data_length, gsize *offset, const guint8 **value, guint16 *value_length)
+{
+    if (!read_card16 (data, data_length, offset, value_length) ||
+        *offset + *value_length > data_length)
+        return FALSE;
+
+    *value = data + *offset;
+    *offset += *value_length;
+
+    return TRUE;
+}
+
+typedef struct
+{
+    guint16 family;
+    const guint8 *address;
+    guint16 address_length;
+    const guint8 *number;
+    guint16 number_length;
+    const guint8 *authorization_name;
+    guint16 authorization_name_length;
+    const guint8 *authorization_data;
+    guint16 authorization_data_length;
+} XAuthorityRecordView;
+
+static gboolean
+read_xauthority_record (const guint8 *data, gsize data_length, gsize *offset, XAuthorityRecordView *record)
+{
+    return read_card16 (data, data_length, offset, &record->family) &&
+           read_xauthority_data (data, data_length, offset, &record->address, &record->address_length) &&
+           read_xauthority_data (data, data_length, offset, &record->number, &record->number_length) &&
+           read_xauthority_data (data, data_length, offset, &record->authorization_name, &record->authorization_name_length) &&
+           read_xauthority_data (data, data_length, offset, &record->authorization_data, &record->authorization_data_length);
+}
+
+static gboolean
+xauthority_data_matches (const guint8 *value, guint16 value_length, const guint8 *expected, gsize expected_length)
+{
+    return value_length == expected_length && memcmp (value, expected, expected_length) == 0;
+}
+
+static gboolean
+xauthority_string_matches (const guint8 *value, guint16 value_length, const gchar *expected)
+{
+    return xauthority_data_matches (value, value_length, (const guint8 *) expected, strlen (expected));
+}
+
+static gboolean
+summarize_stale_xauthority (const gchar *filename, gint *record_count, gint *matching_count, gint *stale_count, gint *unrelated_count)
+{
+    const guint8 stale_cookie[16] = {
+        0x00, 0x01, 0x02, 0x03,
+        0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0A, 0x0B,
+        0x0C, 0x0D, 0x0E, 0x0F
+    };
+    const guint8 unrelated_cookie[16] = {
+        0xF0, 0xF1, 0xF2, 0xF3,
+        0xF4, 0xF5, 0xF6, 0xF7,
+        0xF8, 0xF9, 0xFA, 0xFB,
+        0xFC, 0xFD, 0xFE, 0xFF
+    };
+    g_autofree guint8 *data = NULL;
+    gsize data_length = 0;
+    if (!g_file_get_contents (filename, (gchar **) &data, &data_length, NULL))
+        return FALSE;
+
+    *record_count = 0;
+    *matching_count = 0;
+    *stale_count = 0;
+    *unrelated_count = 0;
+
+    gsize offset = 0;
+    while (offset < data_length)
+    {
+        XAuthorityRecordView record;
+        if (!read_xauthority_record (data, data_length, &offset, &record))
+            return FALSE;
+
+        (*record_count)++;
+
+        gboolean matching_record = record.family == 256 &&
+                                   xauthority_string_matches (record.address, record.address_length, "lightdm-test") &&
+                                   xauthority_string_matches (record.number, record.number_length, "0") &&
+                                   xauthority_string_matches (record.authorization_name, record.authorization_name_length, "MIT-MAGIC-COOKIE-1");
+        if (matching_record)
+        {
+            (*matching_count)++;
+            if (xauthority_data_matches (record.authorization_data, record.authorization_data_length, stale_cookie, sizeof (stale_cookie)))
+                (*stale_count)++;
+        }
+
+        gboolean unrelated_record = record.family == 256 &&
+                                    xauthority_string_matches (record.address, record.address_length, "stale-host") &&
+                                    xauthority_string_matches (record.number, record.number_length, "9") &&
+                                    xauthority_string_matches (record.authorization_name, record.authorization_name_length, "MIT-MAGIC-COOKIE-1") &&
+                                    xauthority_data_matches (record.authorization_data, record.authorization_data_length, unrelated_cookie, sizeof (unrelated_cookie));
+        if (unrelated_record)
+            (*unrelated_count)++;
+    }
+
+    return TRUE;
+}
+
+static gboolean
 sigint_cb (gpointer user_data)
 {
     status_notify ("%s TERMINATE SIGNAL=%d", session_id, SIGINT);
@@ -191,6 +308,22 @@ request_cb (const gchar *name, GHashTable *params)
         g_string_append_c (mode_string, file_info.st_mode & S_IWOTH ? 'w' : '-');
         g_string_append_c (mode_string, file_info.st_mode & S_IXOTH ? 'x' : '-');
         status_notify ("%s CHECK-X-AUTHORITY MODE=%s", session_id, mode_string->str);
+    }
+
+    else if (strcmp (name, "CHECK-X-AUTHORITY-RECORDS") == 0)
+    {
+        g_autofree gchar *xauthority = g_strdup (g_getenv ("XAUTHORITY"));
+        if (!xauthority)
+            xauthority = g_build_filename (g_get_home_dir (), ".Xauthority", NULL);
+
+        gint record_count;
+        gint matching_count;
+        gint stale_count;
+        gint unrelated_count;
+        if (summarize_stale_xauthority (xauthority, &record_count, &matching_count, &stale_count, &unrelated_count))
+            status_notify ("%s CHECK-X-AUTHORITY-RECORDS RECORDS=%d MATCHING=%d STALE=%d UNRELATED=%d", session_id, record_count, matching_count, stale_count, unrelated_count);
+        else
+            status_notify ("%s CHECK-X-AUTHORITY-RECORDS ERROR=INVALID", session_id);
     }
 
     else if (strcmp (name, "WRITE-SHARED-DATA") == 0)

--- a/tests/src/test-x-authority-write.c
+++ b/tests/src/test-x-authority-write.c
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2026 The LightDM Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version. See http://www.gnu.org/copyleft/gpl.html the full text of the
+ * license.
+ */
+
+#include <string.h>
+#include <unistd.h>
+
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include "../../src/x-authority.h"
+
+typedef struct
+{
+    guint16 family;
+    const guint8 *address;
+    guint16 address_length;
+    const gchar *number;
+    const gchar *authorization_name;
+    const guint8 *authorization_data;
+    guint16 authorization_data_length;
+} AuthorityRecord;
+
+static const guint8 target_address[] = "lightdm-test";
+static const guint8 unrelated_address[] = "unrelated-host";
+
+static const guint8 stale_cookie_1[16] = {
+    0x00, 0x01, 0x02, 0x03,
+    0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0A, 0x0B,
+    0x0C, 0x0D, 0x0E, 0x0F
+};
+static const guint8 stale_cookie_2[16] = {
+    0x10, 0x11, 0x12, 0x13,
+    0x14, 0x15, 0x16, 0x17,
+    0x18, 0x19, 0x1A, 0x1B,
+    0x1C, 0x1D, 0x1E, 0x1F
+};
+static const guint8 new_cookie[16] = {
+    0x20, 0x21, 0x22, 0x23,
+    0x24, 0x25, 0x26, 0x27,
+    0x28, 0x29, 0x2A, 0x2B,
+    0x2C, 0x2D, 0x2E, 0x2F
+};
+static const guint8 other_authorization_data[8] = {
+    0x30, 0x31, 0x32, 0x33,
+    0x34, 0x35, 0x36, 0x37
+};
+static const guint8 unrelated_cookie[16] = {
+    0xF0, 0xF1, 0xF2, 0xF3,
+    0xF4, 0xF5, 0xF6, 0xF7,
+    0xF8, 0xF9, 0xFA, 0xFB,
+    0xFC, 0xFD, 0xFE, 0xFF
+};
+
+static const AuthorityRecord matching_record_1 = {
+    XAUTH_FAMILY_LOCAL,
+    target_address,
+    sizeof (target_address) - 1,
+    "0",
+    "MIT-MAGIC-COOKIE-1",
+    stale_cookie_1,
+    sizeof (stale_cookie_1)
+};
+static const AuthorityRecord matching_record_2 = {
+    XAUTH_FAMILY_LOCAL,
+    target_address,
+    sizeof (target_address) - 1,
+    "0",
+    "MIT-MAGIC-COOKIE-1",
+    stale_cookie_2,
+    sizeof (stale_cookie_2)
+};
+static const AuthorityRecord other_authorization_record = {
+    XAUTH_FAMILY_LOCAL,
+    target_address,
+    sizeof (target_address) - 1,
+    "0",
+    "XDM-AUTHORIZATION-1",
+    other_authorization_data,
+    sizeof (other_authorization_data)
+};
+static const AuthorityRecord unrelated_record = {
+    XAUTH_FAMILY_LOCAL,
+    unrelated_address,
+    sizeof (unrelated_address) - 1,
+    "9",
+    "MIT-MAGIC-COOKIE-1",
+    unrelated_cookie,
+    sizeof (unrelated_cookie)
+};
+static const AuthorityRecord new_record = {
+    XAUTH_FAMILY_LOCAL,
+    target_address,
+    sizeof (target_address) - 1,
+    "0",
+    "MIT-MAGIC-COOKIE-1",
+    new_cookie,
+    sizeof (new_cookie)
+};
+
+static void
+append_card16 (GByteArray *data, guint16 value)
+{
+    const guint8 bytes[2] = { value >> 8, value & 0xFF };
+    g_byte_array_append (data, bytes, sizeof (bytes));
+}
+
+static void
+append_data (GByteArray *data, const guint8 *value, guint16 value_length)
+{
+    append_card16 (data, value_length);
+    g_byte_array_append (data, value, value_length);
+}
+
+static void
+append_string (GByteArray *data, const gchar *value)
+{
+    append_data (data, (const guint8 *) value, strlen (value));
+}
+
+static void
+append_record (GByteArray *data, const AuthorityRecord *record)
+{
+    append_card16 (data, record->family);
+    append_data (data, record->address, record->address_length);
+    append_string (data, record->number);
+    append_string (data, record->authorization_name);
+    append_data (data, record->authorization_data, record->authorization_data_length);
+}
+
+static GByteArray *
+serialize_records (const AuthorityRecord *const *records, gsize records_length)
+{
+    GByteArray *data = g_byte_array_new ();
+    for (gsize i = 0; i < records_length; i++)
+        append_record (data, records[i]);
+
+    return data;
+}
+
+static void
+write_records (const gchar *filename, const AuthorityRecord *const *records, gsize records_length)
+{
+    g_autoptr(GByteArray) data = serialize_records (records, records_length);
+    g_autoptr(GError) error = NULL;
+    g_assert_true (g_file_set_contents (filename, (const gchar *) data->data, data->len, &error));
+    g_assert_no_error (error);
+}
+
+static void
+assert_records (const gchar *filename, const AuthorityRecord *const *records, gsize records_length)
+{
+    g_autoptr(GByteArray) expected = serialize_records (records, records_length);
+    g_autofree gchar *actual = NULL;
+    gsize actual_length = 0;
+    g_autoptr(GError) error = NULL;
+    g_assert_true (g_file_get_contents (filename, &actual, &actual_length, &error));
+    g_assert_no_error (error);
+    g_assert_cmpuint (actual_length, ==, expected->len);
+    g_assert_cmpint (memcmp (actual, expected->data, actual_length), ==, 0);
+}
+
+static gchar *
+create_authority_file (const AuthorityRecord *const *records, gsize records_length)
+{
+    g_autoptr(GError) error = NULL;
+    gchar *filename = NULL;
+    gint fd = g_file_open_tmp ("lightdm-xauthority-XXXXXX", &filename, &error);
+    g_assert_no_error (error);
+    g_assert_cmpint (fd, >=, 0);
+    close (fd);
+
+    write_records (filename, records, records_length);
+    return filename;
+}
+
+static XAuthority *
+create_new_authority (void)
+{
+    return x_authority_new (new_record.family,
+                            new_record.address,
+                            new_record.address_length,
+                            new_record.number,
+                            new_record.authorization_name,
+                            new_record.authorization_data,
+                            new_record.authorization_data_length);
+}
+
+static void
+test_replace_deduplicates (void)
+{
+    const AuthorityRecord *input[] = {
+        &matching_record_1,
+        &matching_record_2,
+        &other_authorization_record,
+        &unrelated_record
+    };
+    const AuthorityRecord *expected[] = {
+        &new_record,
+        &other_authorization_record,
+        &unrelated_record
+    };
+    g_autofree gchar *filename = create_authority_file (input, G_N_ELEMENTS (input));
+    g_autoptr(XAuthority) authority = create_new_authority ();
+    g_autoptr(GError) error = NULL;
+
+    g_assert_true (x_authority_write (authority, XAUTH_WRITE_MODE_REPLACE, filename, &error));
+    g_assert_no_error (error);
+    assert_records (filename, expected, G_N_ELEMENTS (expected));
+    g_unlink (filename);
+}
+
+static void
+test_replace_missing_appends (void)
+{
+    const AuthorityRecord *input[] = {
+        &other_authorization_record,
+        &unrelated_record
+    };
+    const AuthorityRecord *expected[] = {
+        &other_authorization_record,
+        &unrelated_record,
+        &new_record
+    };
+    g_autofree gchar *filename = create_authority_file (input, G_N_ELEMENTS (input));
+    g_autoptr(XAuthority) authority = create_new_authority ();
+    g_autoptr(GError) error = NULL;
+
+    g_assert_true (x_authority_write (authority, XAUTH_WRITE_MODE_REPLACE, filename, &error));
+    g_assert_no_error (error);
+    assert_records (filename, expected, G_N_ELEMENTS (expected));
+    g_unlink (filename);
+}
+
+static void
+test_remove_all_matches (void)
+{
+    const AuthorityRecord *input[] = {
+        &matching_record_1,
+        &matching_record_2,
+        &other_authorization_record,
+        &unrelated_record
+    };
+    const AuthorityRecord *expected[] = {
+        &other_authorization_record,
+        &unrelated_record
+    };
+    g_autofree gchar *filename = create_authority_file (input, G_N_ELEMENTS (input));
+    g_autoptr(XAuthority) authority = create_new_authority ();
+    g_autoptr(GError) error = NULL;
+
+    g_assert_true (x_authority_write (authority, XAUTH_WRITE_MODE_REMOVE, filename, &error));
+    g_assert_no_error (error);
+    assert_records (filename, expected, G_N_ELEMENTS (expected));
+    g_unlink (filename);
+}
+
+static void
+test_remove_missing_does_not_append (void)
+{
+    const AuthorityRecord *input[] = {
+        &other_authorization_record,
+        &unrelated_record
+    };
+    g_autofree gchar *filename = create_authority_file (input, G_N_ELEMENTS (input));
+    g_autoptr(XAuthority) authority = create_new_authority ();
+    g_autoptr(GError) error = NULL;
+
+    g_assert_true (x_authority_write (authority, XAUTH_WRITE_MODE_REMOVE, filename, &error));
+    g_assert_no_error (error);
+    assert_records (filename, input, G_N_ELEMENTS (input));
+    g_unlink (filename);
+}
+
+static void
+test_set_replaces_file (void)
+{
+    const AuthorityRecord *input[] = {
+        &matching_record_1,
+        &unrelated_record
+    };
+    const AuthorityRecord *expected[] = { &new_record };
+    g_autofree gchar *filename = create_authority_file (input, G_N_ELEMENTS (input));
+    g_autoptr(XAuthority) authority = create_new_authority ();
+    g_autoptr(GError) error = NULL;
+
+    g_assert_true (x_authority_write (authority, XAUTH_WRITE_MODE_SET, filename, &error));
+    g_assert_no_error (error);
+    assert_records (filename, expected, G_N_ELEMENTS (expected));
+    g_unlink (filename);
+}
+
+int
+main (int argc, char **argv)
+{
+    g_test_init (&argc, &argv, NULL);
+    g_test_add_func ("/x-authority/write/replace-deduplicates", test_replace_deduplicates);
+    g_test_add_func ("/x-authority/write/replace-missing-appends", test_replace_missing_appends);
+    g_test_add_func ("/x-authority/write/remove-all-matches", test_remove_all_matches);
+    g_test_add_func ("/x-authority/write/remove-missing-does-not-append", test_remove_missing_does_not_append);
+    g_test_add_func ("/x-authority/write/set-replaces-file", test_set_replaces_file);
+
+    return g_test_run ();
+}

--- a/tests/test-stale-xauthority
+++ b/tests/test-stale-xauthority
@@ -1,0 +1,2 @@
+#!/bin/sh
+./src/dbus-env ./src/test-runner stale-xauthority test-gobject-greeter


### PR DESCRIPTION
When replacing an Xauthority cookie, keep one matching record and remove duplicate matches. Unrelated records are preserved.

This avoids leaving stale cookies for the current display while keeping manually added Xauthority entries intact.