### PR TITLE
reduce ProcessPrivate 80 to 64 bytes using align and replace gboolean to bool

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -38,14 +38,17 @@ typedef struct
 
     /* File to log to */
     gchar *log_file;
-    gboolean log_stdout;
-    LogMode log_mode;
+    LogMode log_mode; // enum range [-1, 0, 1]
+    gboolean log_stdout : 1; // bool range [0, 1]
+
+    /* TRUE to clear the environment in this process */
+    gboolean clear_environment : 1; // bool range [0, 1]
+
+    /* TRUE if stopping this process (waiting for child process to stop) */
+    gboolean stopping : 1; // bool range [0, 1]
 
     /* Command to run */
     gchar *command;
-
-    /* TRUE to clear the environment in this process */
-    gboolean clear_environment;
 
     /* Environment variables to set */
     GHashTable *env;
@@ -55,9 +58,6 @@ typedef struct
 
     /* Exit status of process */
     int exit_status;
-
-    /* TRUE if stopping this process (waiting for child process to stop) */
-    gboolean stopping;
 
     /* Timeout waiting for process to quit */
     guint quit_timeout;


### PR DESCRIPTION
@JPeisach congratulations, I paid attention to the code again and accidentally noticed that you used a very non-optimized glib gboolean, you can align booleans and reduce the size of the structure to 1 cache line.

More info about gboolean: https://docs.gtk.org/glib/types.html#gboolean

```
There is no validation when assigning to a gboolean variable and so it could
contain any value represented by a gint.
```