### PR TITLE
lightdm: move out of loop strlen call

### DIFF
--- a/liblightdm-gobject/session.c
+++ b/liblightdm-gobject/session.c
@@ -122,6 +122,8 @@ load_sessions_dir (GList *sessions, const gchar *sessions_dir, const gchar *defa
     if (!directory)
         return sessions;
 
+    const size_t ext_len = strlen(".desktop");
+
     while (TRUE)
     {
         const gchar *filename = g_dir_read_name (directory);
@@ -141,7 +143,7 @@ load_sessions_dir (GList *sessions, const gchar *sessions_dir, const gchar *defa
 
         if (result)
         {
-            g_autofree gchar *key = g_strndup (filename, strlen (filename) - strlen (".desktop"));
+            g_autofree gchar *key = g_strndup (filename, strlen(filename) - ext_len);
             LightDMSession *session = load_session (key_file, key, default_type);
             LightDMSessionPrivate *priv = lightdm_session_get_instance_private (session);
             if (session)

--- a/src/dm-tool.c
+++ b/src/dm-tool.c
@@ -284,13 +284,14 @@ main (int argc, char **argv)
         g_autoptr(GVariantIter) seat_iter = NULL;
         g_variant_get (seats, "ao", &seat_iter);
         gchar *seat_path;
+        const size_t prefix_len = strlen ("/org/freedesktop/DisplayManager/");
         while (g_variant_iter_loop (seat_iter, "&o", &seat_path))
         {
             gchar *seat_name;
             g_autoptr(GDBusProxy) proxy = NULL;
 
             if (g_str_has_prefix (seat_path, "/org/freedesktop/DisplayManager/"))
-                seat_name = seat_path + strlen ("/org/freedesktop/DisplayManager/");
+                seat_name = seat_path + prefix_len;
             else
                 seat_name = seat_path;
 
@@ -327,7 +328,7 @@ main (int argc, char **argv)
             {
                 const gchar *session_name;
                 if (g_str_has_prefix (session_path, "/org/freedesktop/DisplayManager/"))
-                    session_name = session_path + strlen ("/org/freedesktop/DisplayManager/");
+                    session_name = session_path + prefix_len;
                 else
                     session_name = session_path;
 

--- a/src/lightdm.c
+++ b/src/lightdm.c
@@ -123,11 +123,12 @@ get_config_sections (const gchar *seat_name)
     GList *config_sections = g_list_append (NULL, g_strdup ("Seat:*"));
 
     g_auto(GStrv) groups = config_get_groups (config_get_instance ());
+    const size_t seat_len = strlen ("Seat:");
     for (gchar **i = groups; *i; i++)
     {
         if (g_str_has_prefix (*i, "Seat:") && strcmp (*i, "Seat:*") != 0)
         {
-            const gchar *seat_name_glob = *i + strlen ("Seat:");
+            const gchar *seat_name_glob = *i + seat_len;
             if (g_pattern_match_simple (seat_name_glob, seat_name ? seat_name : ""))
                 config_sections = g_list_append (config_sections, g_strdup (*i));
         }

--- a/src/session.c
+++ b/src/session.c
@@ -295,11 +295,13 @@ find_env_entry (Session *session, const gchar *name)
 {
     SessionPrivate *priv = session_get_instance_private (session);
 
+    const size_t name_len = strlen (name);
+
     for (GList *link = priv->env; link; link = link->next)
     {
         const gchar *entry = link->data;
 
-        if (g_str_has_prefix (entry, name) && entry[strlen (name)] == '=')
+        if (g_str_has_prefix (entry, name) && entry[name_len] == '=')
             return link;
     }
 


### PR DESCRIPTION
@JPeisach 

Fix common C/C++ compiler flaw is that it doesn't optimize strlen calls inside loops.

Reference:
- https://stackoverflow.com/questions/78827988/why-doesnt-the-compiler-optimize-strlen-calls-in-a-loop-despite-it-being-a-p

Since I started contributing to heavily optimized AV1 decoder ([ffmpeg dav1d](http://aomedia.org/blog%20posts/What-is-dav1d-and-Why-it-Matters/)), there are high performance requirements. I experimentally found out that putting calculated expressions from the body of the loop into separate constants gives a strong two-fold increase. What is strange is the C/C++ compiler that GCC and Clang on -O3 cannot automatically optimize.

It's also visually more readable with a separate const variable.

-  https://code.videolan.org/videolan/dav1d/-/merge_requests/1896
-  https://code.videolan.org/videolan/dav1d/-/merge_requests/1897
-  https://code.videolan.org/videolan/dav1d/-/merge_requests/1898
-  https://code.videolan.org/videolan/dav1d/-/merge_requests/1903