### PR TITLE
greeter: fix possible integer overflow with incorrect format types

### DIFF
--- a/liblightdm-gobject/greeter.c
+++ b/liblightdm-gobject/greeter.c
@@ -409,7 +409,7 @@ read_int (guint8 *message, gsize message_length, gsize *offset)
 {
     if (message_length - *offset < int_length ())
     {
-        g_warning ("Not enough space for int, need %i, got %zi", int_length (), message_length - *offset);
+        g_warning ("Not enough space for int, need %i, got %" G_GSIZE_FORMAT, int_length (), message_length - *offset);
         return 0;
     }
 
@@ -426,7 +426,7 @@ read_string (guint8 *message, gsize message_length, gsize *offset)
     guint32 length = read_int (message, message_length, offset);
     if (message_length - *offset < length)
     {
-        g_warning ("Not enough space for string, need %u, got %zu", length, message_length - *offset);
+        g_warning ("Not enough space for string, need %u, got %" G_GSIZE_FORMAT, length, message_length - *offset);
         return g_strdup ("");
     }
 
@@ -524,7 +524,7 @@ send_message (LightDMGreeter *greeter, guint8 *message, gsize message_length, GE
     if (stated_length != message_length)
     {
         g_set_error (error, LIGHTDM_GREETER_ERROR, LIGHTDM_GREETER_ERROR_COMMUNICATION_ERROR,
-                     "Refusing to write malformed packet to daemon: declared size is %u, but actual size is %zu",
+                     "Refusing to write malformed packet to daemon: declared size is %u, but actual size is %" G_GSIZE_FORMAT,
                      stated_length, message_length);
         return FALSE;
     }
@@ -548,7 +548,7 @@ send_message (LightDMGreeter *greeter, guint8 *message, gsize message_length, GE
         data += n_written;
     }
 
-    g_debug ("Wrote %zi bytes to daemon", message_length);
+    g_debug ("Wrote %" G_GSIZE_FORMAT " bytes to daemon", message_length);
     g_autoptr(GError) flush_error = NULL;
     if (!g_io_channel_flush (priv->to_server_channel, &flush_error))
     {
@@ -859,7 +859,7 @@ recv_message (LightDMGreeter *greeter, gboolean block, guint8 **message, gsize *
             return FALSE;
         }
 
-        g_debug ("Read %zi bytes from daemon", n_read);
+        g_debug ("Read %" G_GSIZE_FORMAT " bytes from daemon", n_read);
 
         priv->n_read += n_read;
     } while (priv->n_read < n_to_read && block);

--- a/src/greeter.c
+++ b/src/greeter.c
@@ -383,7 +383,7 @@ pam_messages_cb (Session *session, Greeter *greeter)
     size_t messages_length = session_get_messages_length (session);
 
     /* Respond to d-bus query with messages */
-    g_debug ("Prompt greeter with %zi message(s)", messages_length);
+    g_debug ("Prompt greeter with %zu message(s)", messages_length);
     guint32 size = int_length () + string_length (session_get_username (session)) + int_length ();
     for (int i = 0; i < messages_length; i++)
         size += int_length () + string_length (messages[i].msg);
@@ -810,7 +810,7 @@ read_int (Greeter *greeter, gsize *offset)
 
     if (priv->n_read - *offset < sizeof (guint32))
     {
-        g_warning ("Not enough space for int, need %zu, got %zu", sizeof (guint32), priv->n_read - *offset);
+        g_warning ("Not enough space for int, need %zu, got %" G_GSIZE_FORMAT, sizeof (guint32), priv->n_read - *offset);
         return 0;
     }
     guint8 *buffer = priv->read_buffer + *offset;
@@ -845,7 +845,7 @@ read_string_full (Greeter *greeter, gsize *offset, void* (*alloc_fn)(size_t n))
     guint32 length = read_int (greeter, offset);
     if (priv->n_read - *offset < length)
     {
-        g_warning ("Not enough space for string, need %u, got %zu", length, priv->n_read - *offset);
+        g_warning ("Not enough space for string, need %u, got %" G_GSIZE_FORMAT, length, priv->n_read - *offset);
         return g_strdup ("");
     }
 


### PR DESCRIPTION
@JPeisach 

- messages_length -> size_t (unsigned int32/64)
- (priv->n_read - *offset) -> gsize
- n_read -> gsize
- (message_length - *offset) -> gsize

liblightdm-gobject
- messages_length -> gsize
- (message_length - *offset) -> gsize