### PR TITLE
perf: optimize user-list, xauth, and xdmcp paths

### DIFF
--- a/common/user-list.c
+++ b/common/user-list.c
@@ -347,6 +347,13 @@ load_passwd_file (CommonUserList *user_list, gboolean emit_add_signal)
 
     setpwent ();
 
+    GHashTable *existing_users_map = g_hash_table_new (g_str_hash, g_str_equal);
+    for (GList *link = priv->users; link; link = link->next)
+    {
+        CommonUser *u = link->data;
+        g_hash_table_insert (existing_users_map, (gpointer) common_user_get_name (u), u);
+    }
+
     GList *users = NULL, *new_users = NULL, *changed_users = NULL;
     while (TRUE)
     {
@@ -376,33 +383,37 @@ load_passwd_file (CommonUserList *user_list, gboolean emit_add_signal)
 
         CommonUser *user = make_passwd_user (user_list, entry);
 
-        /* Update existing users if have them */
-        GList *link;
-        for (link = priv->users; link; link = link->next)
+        /* Update existing users if have them (O(1) hash lookup) */
+        CommonUser *info = g_hash_table_lookup (existing_users_map, common_user_get_name (user));
+        if (info)
         {
-            CommonUser *info = link->data;
-            if (strcmp (common_user_get_name (info), common_user_get_name (user)) == 0)
-            {
-                if (update_passwd_user (info, common_user_get_real_name (user), common_user_get_home_directory (user), common_user_get_shell (user), common_user_get_image (user)))
-                    changed_users = g_list_insert_sorted (changed_users, info, compare_user);
-                g_object_unref (user);
-                user = info;
-                break;
-            }
+            if (update_passwd_user (info, common_user_get_real_name (user), common_user_get_home_directory (user), common_user_get_shell (user), common_user_get_image (user)))
+                changed_users = g_list_prepend (changed_users, info);
+            g_object_unref (user);
+            user = info;
         }
-        if (!link)
+        else
         {
             /* Only notify once we have loaded the user list */
             if (priv->have_users)
-                new_users = g_list_insert_sorted (new_users, user, compare_user);
+                new_users = g_list_prepend (new_users, user);
         }
-        users = g_list_insert_sorted (users, user, compare_user);
+        users = g_list_prepend (users, user);
     }
+
+    g_hash_table_destroy (existing_users_map);
 
     if (errno != 0)
         g_warning ("Failed to read password database: %s", strerror (errno));
 
     endpwent ();
+
+    /* Sort once using optimal O(N log N) mergesort */
+    users = g_list_sort (users, compare_user);
+    if (new_users)
+        new_users = g_list_sort (new_users, compare_user);
+    if (changed_users)
+        changed_users = g_list_sort (changed_users, compare_user);
 
     /* Use new user list */
     GList *old_users = priv->users;
@@ -425,17 +436,14 @@ load_passwd_file (CommonUserList *user_list, gboolean emit_add_signal)
         g_signal_emit (info, user_signals[CHANGED], 0);
     }
     g_list_free (changed_users);
+
+    GHashTable *current_users_set = g_hash_table_new (g_direct_hash, g_direct_equal);
+    for (GList *link = priv->users; link; link = link->next)
+        g_hash_table_add (current_users_set, link->data);
+
     for (GList *link = old_users; link; link = link->next)
     {
-        /* See if this user is in the current list */
-        GList *new_link;
-        for (new_link = priv->users; new_link; new_link = new_link->next)
-        {
-            if (new_link->data == link->data)
-                break;
-        }
-
-        if (!new_link)
+        if (!g_hash_table_contains (current_users_set, link->data))
         {
             CommonUser *info = link->data;
             g_debug ("User %s removed", common_user_get_name (info));
@@ -443,6 +451,7 @@ load_passwd_file (CommonUserList *user_list, gboolean emit_add_signal)
             g_object_unref (info);
         }
     }
+    g_hash_table_destroy (current_users_set);
     g_list_free (old_users);
 }
 

--- a/src/x-authority.c
+++ b/src/x-authority.c
@@ -202,11 +202,10 @@ read_data (gchar *data, gsize data_length, gsize *offset, guint16 length, guint8
     if (data_length - *offset < length)
         return FALSE;
 
-    *value = g_malloc0 (length + 1);
-    for (int i = 0; i < length; i++)
-        (*value)[i] = data[*offset + i];
+    *value = g_malloc (length + 1);
+    memcpy (*value, data + *offset, length);
     *offset += length;
-    (*value)[length] = 0;
+    (*value)[length] = '\0';
 
     return TRUE;
 }
@@ -220,26 +219,29 @@ read_string (gchar *data, gsize data_length, gsize *offset, gchar **value)
     return read_data (data, data_length, offset, length, (guint8 **) value);
 }
 
-static gboolean
-write_uint16 (int fd, guint16 value)
+static inline void
+buffer_append_uint16 (GByteArray *buf, guint16 value)
 {
     guint8 v[2];
     v[0] = value >> 8;
     v[1] = value & 0xFF;
-    return write (fd, v, 2) == 2;
+    g_byte_array_append (buf, v, 2);
 }
 
-static gboolean
-write_data (int fd, const guint8 *value, gsize value_length)
+static inline void
+buffer_append_data (GByteArray *buf, const guint8 *value, gsize value_length)
 {
-    return write (fd, value, value_length) == value_length;
+    if (value && value_length > 0)
+        g_byte_array_append (buf, value, value_length);
 }
 
-static gboolean
-write_string (int fd, const gchar *value)
+static inline void
+buffer_append_string (GByteArray *buf, const gchar *value)
 {
-    size_t value_length = strlen (value);
-    return write_uint16 (fd, value_length) && write_data (fd, (guint8 *) value, value_length);
+    size_t value_length = value ? strlen (value) : 0;
+    buffer_append_uint16 (buf, (guint16) value_length);
+    if (value && value_length > 0)
+        g_byte_array_append (buf, (const guint8 *) value, value_length);
 }
 
 gboolean
@@ -285,9 +287,7 @@ x_authority_write (XAuthority *auth, XAuthWriteMode mode, const gchar *filename,
         gboolean address_matches = FALSE;
         if (priv->address_length == a_priv->address_length)
         {
-            guint16 i;
-            for (i = 0; i < priv->address_length && priv->address[i] == a_priv->address[i]; i++);
-            address_matches = i == priv->address_length;
+            address_matches = (memcmp (priv->address, a_priv->address, priv->address_length) == 0);
         }
 
         /* If this record matches, then update or delete it */
@@ -303,18 +303,38 @@ x_authority_write (XAuthority *auth, XAuthWriteMode mode, const gchar *filename,
                 x_authority_set_authorization_data (a, priv->authorization_data, priv->authorization_data_length);
         }
 
-        records = g_list_append (records, g_steal_pointer (&a));
+        records = g_list_prepend (records, g_steal_pointer (&a));
     }
 
     /* If didn't exist, then add a new one */
     if (!matched)
-        records = g_list_append (records, g_object_ref (auth));
+        records = g_list_prepend (records, g_object_ref (auth));
 
-    /* Write records back */
+    records = g_list_reverse (records);
+
+    /* Build binary image in memory buffer */
+    GByteArray *output_buf = g_byte_array_new ();
+    for (GList *link = records; link; link = link->next)
+    {
+        XAuthority *a = link->data;
+        XAuthorityPrivate *a_priv = x_authority_get_instance_private (a);
+
+        buffer_append_uint16 (output_buf, a_priv->family);
+        buffer_append_uint16 (output_buf, a_priv->address_length);
+        buffer_append_data (output_buf, a_priv->address, a_priv->address_length);
+        buffer_append_string (output_buf, a_priv->number);
+        buffer_append_string (output_buf, a_priv->authorization_name);
+        buffer_append_uint16 (output_buf, a_priv->authorization_data_length);
+        buffer_append_data (output_buf, a_priv->authorization_data, a_priv->authorization_data_length);
+    }
+    g_list_free_full (records, g_object_unref);
+
+    /* Write records back in a single atomic I/O write */
     errno = 0;
-    int output_fd = g_open (filename, O_WRONLY | O_CREAT | O_TRUNC , S_IRUSR | S_IWUSR);
+    int output_fd = g_open (filename, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
     if (output_fd < 0)
     {
+        g_byte_array_free (output_buf, TRUE);
         g_set_error (error,
                      G_FILE_ERROR,
                      g_file_error_from_errno (errno),
@@ -325,21 +345,9 @@ x_authority_write (XAuthority *auth, XAuthWriteMode mode, const gchar *filename,
     }
 
     errno = 0;
-    gboolean result = TRUE;
-    for (GList *link = records; link && result; link = link->next)
-    {
-        XAuthority *a = link->data;
-        XAuthorityPrivate *a_priv = x_authority_get_instance_private (a);
-
-        result = write_uint16 (output_fd, a_priv->family) &&
-                 write_uint16 (output_fd, a_priv->address_length) &&
-                 write_data (output_fd, a_priv->address, a_priv->address_length) &&
-                 write_string (output_fd, a_priv->number) &&
-                 write_string (output_fd, a_priv->authorization_name) &&
-                 write_uint16 (output_fd, a_priv->authorization_data_length) &&
-                 write_data (output_fd, a_priv->authorization_data, a_priv->authorization_data_length);
-    }
-    g_list_free_full (records, g_object_unref);
+    ssize_t written = write (output_fd, output_buf->data, output_buf->len);
+    gboolean result = (written == (ssize_t) output_buf->len);
+    g_byte_array_free (output_buf, TRUE);
 
     fsync (output_fd);
     close (output_fd);

--- a/src/xdmcp-protocol.c
+++ b/src/xdmcp-protocol.c
@@ -54,20 +54,34 @@ static void
 read_data (PacketReader *reader, XDMCPData *data)
 {
     data->length = read_card16 (reader);
+    if (reader->overflow || reader->remaining < data->length)
+    {
+        reader->overflow = TRUE;
+        data->data = NULL;
+        return;
+    }
     data->data = g_malloc (sizeof (guint8) * data->length);
-    for (guint16 i = 0; i < data->length; i++)
-        data->data[i] = read_card8 (reader);
+    if (data->length > 0)
+        memcpy (data->data, reader->data, data->length);
+    reader->data += data->length;
+    reader->remaining -= data->length;
 }
 
 static gchar *
 read_string (PacketReader *reader)
 {
     guint16 length = read_card16 (reader);
+    if (reader->overflow || reader->remaining < length)
+    {
+        reader->overflow = TRUE;
+        return g_strdup ("");
+    }
     gchar *string = g_malloc (sizeof (gchar) * (length + 1));
-    guint16 i;
-    for (i = 0; i < length; i++)
-        string[i] = (gchar) read_card8 (reader);
-    string[i] = '\0';
+    if (length > 0)
+        memcpy (string, reader->data, length);
+    string[length] = '\0';
+    reader->data += length;
+    reader->remaining -= length;
 
     return string;
 }
@@ -109,33 +123,62 @@ write_card8 (PacketWriter *writer, guint8 value)
 static void
 write_card16 (PacketWriter *writer, guint16 value)
 {
-    write_card8 (writer, value >> 8);
-    write_card8 (writer, value & 0xFF);
+    if (writer->remaining < 2)
+    {
+        writer->overflow = TRUE;
+        return;
+    }
+    writer->data[0] = (value >> 8) & 0xFF;
+    writer->data[1] = value & 0xFF;
+    writer->data += 2;
+    writer->remaining -= 2;
 }
 
 static void
 write_card32 (PacketWriter *writer, guint32 value)
 {
-    write_card8 (writer, (value >> 24) & 0xFF);
-    write_card8 (writer, (value >> 16) & 0xFF);
-    write_card8 (writer, (value >> 8) & 0xFF);
-    write_card8 (writer, value & 0xFF);
+    if (writer->remaining < 4)
+    {
+        writer->overflow = TRUE;
+        return;
+    }
+    writer->data[0] = (value >> 24) & 0xFF;
+    writer->data[1] = (value >> 16) & 0xFF;
+    writer->data[2] = (value >> 8) & 0xFF;
+    writer->data[3] = value & 0xFF;
+    writer->data += 4;
+    writer->remaining -= 4;
 }
 
 static void
 write_data (PacketWriter *writer, const XDMCPData *value)
 {
     write_card16 (writer, value->length);
-    for (guint16 i = 0; i < value->length; i++)
-        write_card8 (writer, value->data[i]);
+    if (writer->overflow || writer->remaining < value->length)
+    {
+        writer->overflow = TRUE;
+        return;
+    }
+    if (value->length > 0 && value->data != NULL)
+        memcpy (writer->data, value->data, value->length);
+    writer->data += value->length;
+    writer->remaining -= value->length;
 }
 
 static void
 write_string (PacketWriter *writer, const gchar *value)
 {
-    write_card16 (writer, strlen (value));
-    for (const gchar *c = value; *c; c++)
-        write_card8 (writer, *c);
+    size_t length = value ? strlen (value) : 0;
+    write_card16 (writer, (guint16) length);
+    if (writer->overflow || writer->remaining < length)
+    {
+        writer->overflow = TRUE;
+        return;
+    }
+    if (length > 0)
+        memcpy (writer->data, value, length);
+    writer->data += length;
+    writer->remaining -= length;
 }
 
 static void


### PR DESCRIPTION
@jpeisach,

Using perf benchmarks from this PR (https://github.com/ubuntu/lightdm/pull/477), we were able to carry out useful algorithmic optimization, namely:

User List
   - Replace O(N^2) per-entry g_list_insert_sorted() during passwd loading with O(1) prepend and a single O(N log N) g_list_sort() merge sort
   - Replace O(N^2) nested list traversals for existing and removed users with O(1) hash tables

Xauthority
   - Buffer all serialized records into a GByteArray in memory before writing to disk in a single atomic write() syscall, replacing up to 350 separate syscalls per update
   - Replace byte-by-byte loops in read_data() with block memcpy()
   - Replace O(N^2) g_list_append() with O(N) prepend + reverse

XDMCP
   - Replace byte-by-byte loops in read_data(), read_string(), write_data(), and write_string() with single-check block memcpy() operations
   
I post visual graphs my benchmarks on NUMA server motherboard 2x Xeon E5-2699v3 (Haswell 2014 year - 36 core 72 threads)

Two commits were compared: 
- integrate-benchmarks branch https://github.com/ubuntu/lightdm/pull/477/commits/4bf60bab405f08ecff846710f308bd90f06049d0 (w/o optimizations)
- optimize branch https://github.com/ubuntu/lightdm/commit/1dd9c812c6bf338cb4aff3cd070ef46f1caf8800

Attention on lookup_by_name from user list, change math algorithm speedup in 371x times !!!

<img width="3581" height="2395" alt="image" src="https://github.com/user-attachments/assets/ef917006-81d3-410d-a7ff-d2bc84f835d4" />

<img width="2389" height="1578" alt="image" src="https://github.com/user-attachments/assets/f03c7864-b41f-4624-a290-e911810b6f54" />

<img width="2777" height="1227" alt="image" src="https://github.com/user-attachments/assets/cf945d02-9b65-4d57-a586-05d7b32ce7eb" />

<img width="2978" height="1240" alt="image" src="https://github.com/user-attachments/assets/1696b4fa-8c35-4b5c-ae15-09f45f329b7d" />
